### PR TITLE
Add GLUT samples using OpenGL subset

### DIFF
--- a/samples/opengl/GL/gl.h
+++ b/samples/opengl/GL/gl.h
@@ -1,0 +1,328 @@
+#ifndef __GL_H__
+#define __GL_H__
+
+// Some code stolen from mesa:
+// Copyright (C) 1999-2005  Brian Paul   All Rights Reserved.
+
+#if 0
+#include <assert.h>
+#else
+#define assert(x)
+#endif
+
+#include <stdbool.h>
+typedef int bool;
+
+#include <stdint.h>
+
+#define MASK(mask, val) (((val) << (ffs(mask)-1)) & (mask))
+
+typedef int GLenum;
+typedef int GLint;
+typedef float GLfloat;
+typedef int GLsizei;
+typedef double GLdouble;
+typedef unsigned int GLbitfield;
+
+#define GL_PROJECTION 0
+#define GL_MODELVIEW 1
+#define GL_TRIANGLES NV097_SET_BEGIN_END_OP_TRIANGLES
+#define GL_QUADS NV097_SET_BEGIN_END_OP_QUADS
+
+#define GL_COLOR_BUFFER_BIT 0x1
+#define GL_DEPTH_BUFFER_BIT 0x2
+
+
+static float projectionMatrix[4*4];
+static float modelViewMatrix[4*4];
+
+static float* targetMatrix = NULL;
+
+static void matrix_identity(float* out) {
+  memset(out, 0x00, 4 * 4 * sizeof(float));
+  for(int i = 0; i < 4; i++) {
+    out[i*4+i] = 1.0f;
+  }
+}
+
+#define A(row,col)  a[(col<<2)+row]
+#define B(row,col)  b[(col<<2)+row]
+#define P(row,col) product[(col<<2)+row]
+static void matmul4( GLfloat *product, const GLfloat *a, const GLfloat *b )
+{
+   GLint i;
+   for (i = 0; i < 4; i++) {
+      const GLfloat ai0=A(i,0),  ai1=A(i,1),  ai2=A(i,2),  ai3=A(i,3);
+      P(i,0) = ai0 * B(0,0) + ai1 * B(1,0) + ai2 * B(2,0) + ai3 * B(3,0);
+      P(i,1) = ai0 * B(0,1) + ai1 * B(1,1) + ai2 * B(2,1) + ai3 * B(3,1);
+      P(i,2) = ai0 * B(0,2) + ai1 * B(1,2) + ai2 * B(2,2) + ai3 * B(3,2);
+      P(i,3) = ai0 * B(0,3) + ai1 * B(1,3) + ai2 * B(2,3) + ai3 * B(3,3);
+   }
+}
+#undef A
+#undef B
+#undef P
+
+
+static void update_matrices() {
+  uint32_t *p;
+
+  p = pb_begin();
+  pb_push(p++, NV097_SET_PROJECTION_MATRIX, 4 * 4); //bit 30 means all params go to same register 0x1810
+  for(int i = 0; i < 4; i++) {
+    for(int j = 0; j < 4; j++) {
+      *(p++) = *(uint32_t*)&projectionMatrix[i*4+j];
+    }
+  }
+  pb_end(p);
+
+  //FIXME: Use the real modelview
+  p = pb_begin();
+  pb_push(p++, NV097_SET_MODEL_VIEW_MATRIX, 4 * 4); //bit 30 means all params go to same register 0x1810
+  for(int i = 0; i < 4; i++) {
+    for(int j = 0; j < 4; j++) {
+      *(p++) = *(uint32_t*)&modelViewMatrix[i*4+j];
+    }
+  }
+  pb_end(p);
+
+  // Generate a composite matrix
+  float compositeMatrix[4*4];
+  matmul4(compositeMatrix, modelViewMatrix, projectionMatrix);
+  p = pb_begin();
+  pb_push(p++, NV097_SET_COMPOSITE_MATRIX, 4 * 4); //bit 30 means all params go to same register 0x1810
+  for(int i = 0; i < 4; i++) {
+    for(int j = 0; j < 4; j++) {
+      *(p++) = *(uint32_t*)&compositeMatrix[i*4+j];
+    }
+  }
+  pb_end(p);
+}
+
+
+#if 0
+
+  /* Clear all attributes */
+  pb_push(p++, NV097_SET_VERTEX_DATA_ARRAY_FORMAT,16);
+  for(i = 0; i < 16; i++) {
+      *(p++) = NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F;
+  }
+  pb_end(p);
+
+  /* Set one attribute */
+  pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_FORMAT + index*4,
+      MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE, format) | \
+      MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_SIZE, size) | \
+      MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_STRIDE, stride));
+  p += 2;
+  pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_OFFSET + index*4, (uint32_t)data & 0x03ffffff);
+  p += 2;
+
+#endif
+
+void glBegin(GLenum mode) {
+  update_matrices();
+  uint32_t *p = pb_begin();
+  pb_push1(p, NV097_SET_BEGIN_END, mode); p += 2;
+  pb_end(p);
+}
+
+void glEnd(void) {
+  uint32_t *p = pb_begin();
+  pb_push1(p,NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END); p += 2;
+  pb_end(p);
+}
+
+#if 0
+/* Send draw commands for the triangles */
+//FIXME: void glDrawArrays(GLenum mode, GLint first, GLsizei count);
+static void draw_arrays(unsigned int mode, int start, int count)
+{
+  update_matrices();
+
+  uint32_t *p = pb_begin();
+  pb_push1(p, NV097_SET_BEGIN_END, mode); p += 2;
+
+  pb_push(p++,0x40000000|NV097_DRAW_ARRAYS,1); //bit 30 means all params go to same register 0x1810
+  *(p++) = MASK(NV097_DRAW_ARRAYS_COUNT, (count-1)) | MASK(NV097_DRAW_ARRAYS_START_INDEX, start);
+
+  pb_push1(p,NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END); p += 2;
+  pb_end(p);
+}
+#endif
+
+void glViewport(GLint x, GLint y, GLsizei width, GLsizei height) {
+  //FIXME: Do this
+  //pb_set_viewport(x, y, width, height, 0.0f, 1.0f);
+}
+
+void glMatrixMode(GLenum mode) {
+
+  //FIXME: Should be done in some constructor function,
+  //       Just not sure if nxdk does those yet :(
+  static bool init = false;
+  if (init == false) {
+    
+    matrix_identity(projectionMatrix);
+    matrix_identity(modelViewMatrix);
+
+    init = true;
+  }
+
+  if (mode == GL_PROJECTION) {
+    targetMatrix = projectionMatrix;
+  } else if (mode == GL_MODELVIEW) {
+    targetMatrix = modelViewMatrix;
+  }
+}
+
+void glLoadIdentity(void) {
+  matrix_identity(targetMatrix);
+}
+
+
+void glOrtho(GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble nearval, GLdouble farval) {
+  //FIXME: Multiply this onto the existing stack - don't overwrite
+
+
+   GLfloat m[16];
+
+#define M(row,col)  m[col*4+row]
+   M(0,0) = 2.0F / (right-left);
+   M(0,1) = 0.0F;
+   M(0,2) = 0.0F;
+   M(0,3) = -(right+left) / (right-left);
+
+   M(1,0) = 0.0F;
+   M(1,1) = 2.0F / (top-bottom);
+   M(1,2) = 0.0F;
+   M(1,3) = -(top+bottom) / (top-bottom);
+
+   M(2,0) = 0.0F;
+   M(2,1) = 0.0F;
+   M(2,2) = -2.0F / (farval-nearval);
+   M(2,3) = -(farval+nearval) / (farval-nearval);
+
+   M(3,0) = 0.0F;
+   M(3,1) = 0.0F;
+   M(3,2) = 0.0F;
+   M(3,3) = 1.0F;
+#undef M
+
+  float t[4 * 4];
+  matmul4( t, m, targetMatrix);
+  memcpy(targetMatrix, t, sizeof(t));
+}
+
+//FIXME:   glScalef(1, -1, 1);           /* Invert Y axis so increasing Y goes down. */
+void glScalef(GLfloat x, GLfloat y, GLfloat z) {
+}
+
+//FIXME:   glTranslatef(0, -h, 0);       /* Shift origin up to upper-left corner. */
+void glTranslatef(GLfloat x, GLfloat y, GLfloat z) {
+}
+
+//FIXME:   glRotatef(60, 1.0, 0.0, 0.0); (used to rotate cube)
+void glRotatef(GLfloat angle, GLfloat x, GLfloat y, GLfloat z) {
+}
+
+#define GL_LIGHT0 0
+#define GL_DIFFUSE 0
+#define GL_POSITION 1
+
+void glLightfv(GLenum light, GLenum pname, GLfloat* param) {
+  //FIXME: Add light support
+}
+
+#define GL_DEPTH_TEST 0
+#define GL_LIGHTING 1
+
+void glEnable(GLenum cap) {
+  switch(cap) {
+  default:
+    assert(false);
+  }
+}
+
+void glClear(GLbitfield mask) {
+
+  int width = pb_back_buffer_width();
+  int height = pb_back_buffer_height();
+
+  /* Clear depth & stencil buffers */
+  if (mask & GL_DEPTH_BUFFER_BIT) {
+    pb_erase_depth_stencil_buffer(0, 0, width, height);
+  }
+
+  if (mask & GL_COLOR_BUFFER_BIT) {
+    pb_fill(0, 0, width, height, 0x00FF00FF);
+  }
+}
+
+static void vertex_attribute_4f(int index, float x, float y, float z, float w) {
+  int reg = NV097_SET_VERTEX_DATA4F_M + (index * 4) * 4;
+
+  uint32_t *p = pb_begin();
+  pb_push(p++, reg, 4); //bit 30 means all params go to same register 0x1810
+  *(p++) = *(uint32_t*)&x;
+  *(p++) = *(uint32_t*)&y;
+  *(p++) = *(uint32_t*)&z;
+  *(p++) = *(uint32_t*)&w;
+  pb_end(p);
+}
+
+static void vertex_attribute_3f(int index, float x, float y, float z) {
+  vertex_attribute_4f(index, x, y, z, 1.0f);
+}
+
+static void vertex_attribute_2i(int index, int16_t x, int16_t y) {
+  int reg = NV097_SET_VERTEX_DATA2S + index * 4;
+
+  uint32_t *p = pb_begin();
+  pb_push(p++, reg, 1);
+  *(p++) = x | (y << 16);
+  pb_end(p);
+}
+
+void glColor3f(GLfloat red, GLfloat green, GLfloat blue) {
+  vertex_attribute_3f(3, red, green, blue);
+}
+
+
+void glVertex3f(GLfloat x, GLfloat y, GLfloat z) {
+  vertex_attribute_3f(0, x, y, z);
+}
+
+void glVertex3fv(const GLfloat * v) {
+  glVertex3f(v[0], v[1], v[2]);
+}
+
+void glVertex2i(GLint x, GLint y) {
+  vertex_attribute_2i(0, x, y);
+}
+
+void glNormal3f(GLfloat x, GLfloat y, GLfloat z) {
+  vertex_attribute_3f(2, x, y, z);
+}
+
+void glNormal3fv(const GLfloat * v) {
+  glNormal3f(v[0], v[1], v[2]);
+}
+
+
+void glFlush(void) {
+  //FIXME: Send command stream only, not sure why we wait here, check pbkit docs
+  while(pb_busy()) {
+      /* Wait for completion... */
+  }
+}
+
+void glFinish(void) {
+  //FIXME: Why does pb_finished swap buffers? check pbkit docs
+  /* Swap buffers (if we can) */
+  while (pb_finished()) {
+      /* Not ready to swap yet */
+  }
+}
+
+#endif

--- a/samples/opengl/GL/gl.h
+++ b/samples/opengl/GL/gl.h
@@ -47,6 +47,144 @@ static void matrix_identity(float* out) {
   }
 }
 
+static void _math_matrix_scale(GLfloat *m, GLfloat x, GLfloat y, GLfloat z ) {
+   m[0] *= x;   m[4] *= y;   m[8]  *= z;
+   m[1] *= x;   m[5] *= y;   m[9]  *= z;
+   m[2] *= x;   m[6] *= y;   m[10] *= z;
+   m[3] *= x;   m[7] *= y;   m[11] *= z;
+}
+
+
+bool invert(float invOut[16], const float m[16])
+{
+    float inv[16], det;
+    int i;
+
+    inv[0] = m[5]  * m[10] * m[15] - 
+             m[5]  * m[11] * m[14] - 
+             m[9]  * m[6]  * m[15] + 
+             m[9]  * m[7]  * m[14] +
+             m[13] * m[6]  * m[11] - 
+             m[13] * m[7]  * m[10];
+
+    inv[4] = -m[4]  * m[10] * m[15] + 
+              m[4]  * m[11] * m[14] + 
+              m[8]  * m[6]  * m[15] - 
+              m[8]  * m[7]  * m[14] - 
+              m[12] * m[6]  * m[11] + 
+              m[12] * m[7]  * m[10];
+
+    inv[8] = m[4]  * m[9] * m[15] - 
+             m[4]  * m[11] * m[13] - 
+             m[8]  * m[5] * m[15] + 
+             m[8]  * m[7] * m[13] + 
+             m[12] * m[5] * m[11] - 
+             m[12] * m[7] * m[9];
+
+    inv[12] = -m[4]  * m[9] * m[14] + 
+               m[4]  * m[10] * m[13] +
+               m[8]  * m[5] * m[14] - 
+               m[8]  * m[6] * m[13] - 
+               m[12] * m[5] * m[10] + 
+               m[12] * m[6] * m[9];
+
+    inv[1] = -m[1]  * m[10] * m[15] + 
+              m[1]  * m[11] * m[14] + 
+              m[9]  * m[2] * m[15] - 
+              m[9]  * m[3] * m[14] - 
+              m[13] * m[2] * m[11] + 
+              m[13] * m[3] * m[10];
+
+    inv[5] = m[0]  * m[10] * m[15] - 
+             m[0]  * m[11] * m[14] - 
+             m[8]  * m[2] * m[15] + 
+             m[8]  * m[3] * m[14] + 
+             m[12] * m[2] * m[11] - 
+             m[12] * m[3] * m[10];
+
+    inv[9] = -m[0]  * m[9] * m[15] + 
+              m[0]  * m[11] * m[13] + 
+              m[8]  * m[1] * m[15] - 
+              m[8]  * m[3] * m[13] - 
+              m[12] * m[1] * m[11] + 
+              m[12] * m[3] * m[9];
+
+    inv[13] = m[0]  * m[9] * m[14] - 
+              m[0]  * m[10] * m[13] - 
+              m[8]  * m[1] * m[14] + 
+              m[8]  * m[2] * m[13] + 
+              m[12] * m[1] * m[10] - 
+              m[12] * m[2] * m[9];
+
+    inv[2] = m[1]  * m[6] * m[15] - 
+             m[1]  * m[7] * m[14] - 
+             m[5]  * m[2] * m[15] + 
+             m[5]  * m[3] * m[14] + 
+             m[13] * m[2] * m[7] - 
+             m[13] * m[3] * m[6];
+
+    inv[6] = -m[0]  * m[6] * m[15] + 
+              m[0]  * m[7] * m[14] + 
+              m[4]  * m[2] * m[15] - 
+              m[4]  * m[3] * m[14] - 
+              m[12] * m[2] * m[7] + 
+              m[12] * m[3] * m[6];
+
+    inv[10] = m[0]  * m[5] * m[15] - 
+              m[0]  * m[7] * m[13] - 
+              m[4]  * m[1] * m[15] + 
+              m[4]  * m[3] * m[13] + 
+              m[12] * m[1] * m[7] - 
+              m[12] * m[3] * m[5];
+
+    inv[14] = -m[0]  * m[5] * m[14] + 
+               m[0]  * m[6] * m[13] + 
+               m[4]  * m[1] * m[14] - 
+               m[4]  * m[2] * m[13] - 
+               m[12] * m[1] * m[6] + 
+               m[12] * m[2] * m[5];
+
+    inv[3] = -m[1] * m[6] * m[11] + 
+              m[1] * m[7] * m[10] + 
+              m[5] * m[2] * m[11] - 
+              m[5] * m[3] * m[10] - 
+              m[9] * m[2] * m[7] + 
+              m[9] * m[3] * m[6];
+
+    inv[7] = m[0] * m[6] * m[11] - 
+             m[0] * m[7] * m[10] - 
+             m[4] * m[2] * m[11] + 
+             m[4] * m[3] * m[10] + 
+             m[8] * m[2] * m[7] - 
+             m[8] * m[3] * m[6];
+
+    inv[11] = -m[0] * m[5] * m[11] + 
+               m[0] * m[7] * m[9] + 
+               m[4] * m[1] * m[11] - 
+               m[4] * m[3] * m[9] - 
+               m[8] * m[1] * m[7] + 
+               m[8] * m[3] * m[5];
+
+    inv[15] = m[0] * m[5] * m[10] - 
+              m[0] * m[6] * m[9] - 
+              m[4] * m[1] * m[10] + 
+              m[4] * m[2] * m[9] + 
+              m[8] * m[1] * m[6] - 
+              m[8] * m[2] * m[5];
+
+    det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
+
+    if (det == 0)
+        return false;
+
+    det = 1.0 / det;
+
+    for (i = 0; i < 16; i++)
+        invOut[i] = inv[i] * det;
+
+    return true;
+}
+
 #define A(row,col)  a[(col<<2)+row]
 #define B(row,col)  b[(col<<2)+row]
 #define P(row,col) product[(col<<2)+row]
@@ -65,11 +203,40 @@ static void matmul4( GLfloat *product, const GLfloat *a, const GLfloat *b )
 #undef B
 #undef P
 
+void ortho(float* r, GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble nearval, GLdouble farval) {
+  //FIXME: Multiply this onto the existing stack - don't overwrite
+
+   GLfloat m[16];
+
+#define M(row,col)  m[col*4+row]
+   M(0,0) = 2.0F / (right-left);
+   M(0,1) = 0.0F;
+   M(0,2) = 0.0F;
+   M(0,3) = -(right+left) / (right-left);
+
+   M(1,0) = 0.0F;
+   M(1,1) = 2.0F / (top-bottom);
+   M(1,2) = 0.0F;
+   M(1,3) = -(top+bottom) / (top-bottom);
+
+   M(2,0) = 0.0F;
+   M(2,1) = 0.0F;
+   M(2,2) = -2.0F / (farval-nearval);
+   M(2,3) = -(farval+nearval) / (farval-nearval);
+
+   M(3,0) = 0.0F;
+   M(3,1) = 0.0F;
+   M(3,2) = 0.0F;
+   M(3,3) = 1.0F;
+#undef M
+
+  memcpy(r, m, sizeof(m));
+}
 
 static void update_matrices() {
   uint32_t *p;
 
-  matrix_identity(projectionMatrix);
+  //matrix_identity(projectionMatrix);
   matrix_identity(modelViewMatrix);
 
   p = pb_begin();
@@ -91,10 +258,25 @@ static void update_matrices() {
   }
   pb_end(p);
 
+
+  float tmp[4*4];
+
+  // Undo the viewport transform
+  //FIXME: Use actual viewport settings
+  float undoViewport[4*4];
+  ortho(tmp, 0.0f, 640.0f, 0.0f, 480.0f, 0.0f, 0xFFFFFF);
+  invert(undoViewport, tmp);
+
+
+
   // Generate a composite matrix
   float compositeMatrix[4*4];
-  //matmul4(compositeMatrix, modelViewMatrix, projectionMatrix);
-  memcpy(compositeMatrix, projectionMatrix, sizeof(compositeMatrix));
+  matmul4(compositeMatrix, modelViewMatrix, projectionMatrix);
+
+
+  memcpy(tmp, compositeMatrix, sizeof(tmp));
+  matmul4(compositeMatrix, tmp, undoViewport);
+
   p = pb_begin();
   pb_push(p++, NV097_SET_COMPOSITE_MATRIX, 4 * 4);
   for(int i = 0; i < 4; i++) {
@@ -187,51 +369,55 @@ void glLoadIdentity(void) {
 }
 
 
+
 void glOrtho(GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble nearval, GLdouble farval) {
   //FIXME: Multiply this onto the existing stack - don't overwrite
 
-   GLfloat m[16];
-
-#define M(row,col)  m[col*4+row]
-   M(0,0) = 2.0F / (right-left);
-   M(0,1) = 0.0F;
-   M(0,2) = 0.0F;
-   M(0,3) = -(right+left) / (right-left);
-
-   M(1,0) = 0.0F;
-   M(1,1) = 2.0F / (top-bottom);
-   M(1,2) = 0.0F;
-   M(1,3) = -(top+bottom) / (top-bottom);
-
-   M(2,0) = 0.0F;
-   M(2,1) = 0.0F;
-   M(2,2) = -2.0F / (farval-nearval);
-   M(2,3) = -(farval+nearval) / (farval-nearval);
-
-   M(3,0) = 0.0F;
-   M(3,1) = 0.0F;
-   M(3,2) = 0.0F;
-   M(3,3) = 1.0F;
-#undef M
+  GLfloat m[16];
+  ortho(m, left, right, bottom, top, nearval, farval);
 
   float t[4 * 4];
-  matmul4( t, m, targetMatrix);
+  matmul4( t, targetMatrix, m);
   memcpy(targetMatrix, t, sizeof(t));
 
-  memcpy(targetMatrix, m, sizeof(m));
+//  memcpy(targetMatrix, m, sizeof(m));
 }
+
 
 //FIXME:   glScalef(1, -1, 1);           /* Invert Y axis so increasing Y goes down. */
 void glScalef(GLfloat x, GLfloat y, GLfloat z) {
+  float m[4*4];
+  matrix_identity(m);
+  _math_matrix_scale(m, x, y, z);
+
+  float t[4 * 4];
+  matmul4( t, targetMatrix, m);
+  memcpy(targetMatrix, t, sizeof(t));
+}
+
+static void _math_matrix_translate(GLfloat *m, GLfloat x, GLfloat y, GLfloat z ) {
+   m[12] = m[0] * x + m[4] * y + m[8]  * z + m[12];
+   m[13] = m[1] * x + m[5] * y + m[9]  * z + m[13];
+   m[14] = m[2] * x + m[6] * y + m[10] * z + m[14];
+   m[15] = m[3] * x + m[7] * y + m[11] * z + m[15];
 }
 
 //FIXME:   glTranslatef(0, -h, 0);       /* Shift origin up to upper-left corner. */
 void glTranslatef(GLfloat x, GLfloat y, GLfloat z) {
+  float m[4*4];
+  matrix_identity(m);
+  _math_matrix_translate(m, x, y, z);
+
+  float t[4 * 4];
+  matmul4( t, targetMatrix, m);
+  memcpy(targetMatrix, t, sizeof(t));
 }
 
+#if 0
 //FIXME:   glRotatef(60, 1.0, 0.0, 0.0); (used to rotate cube)
 void glRotatef(GLfloat angle, GLfloat x, GLfloat y, GLfloat z) {
 }
+#endif
 
 #define GL_LIGHT0 0
 #define GL_DIFFUSE 0
@@ -282,7 +468,7 @@ static void vertex_attribute_3f(int index, float x, float y, float z) {
   vertex_attribute_4f(index, x, y, z, 1.0f);
 }
 
-static void vertex_attribute_2i(int index, int16_t x, int16_t y) {
+static void vertex_attribute_2s(int index, int16_t x, int16_t y) {
   int reg = NV097_SET_VERTEX_DATA2S + index * 4;
 
   uint32_t *p = pb_begin();
@@ -312,8 +498,9 @@ void glVertex3fv(const GLfloat * v) {
   glVertex3f(v[0], v[1], v[2]);
 }
 
-void glVertex2i(GLint x, GLint y) {
-  vertex_attribute_2i(0, x, y);
+//FIXME: This is wrong! Xbox 2s seems to normalize values (XQEMU does it at least), so this gets all messed up
+void glVertex2s(GLint x, GLint y) {
+  vertex_attribute_2s(0, x, y);
 }
 
 void glColor4ub(GLubyte red, GLubyte green, GLubyte blue, GLubyte alpha) {

--- a/samples/opengl/GL/glu.h
+++ b/samples/opengl/GL/glu.h
@@ -1,0 +1,11 @@
+#include "gl.h"
+
+void gluLookAt(GLdouble eyeX, GLdouble eyeY, GLdouble eyeZ,
+               GLdouble centerX, GLdouble centerY, GLdouble centerZ,
+               GLdouble upX, GLdouble upY, GLdouble upZ) {
+  //FIXME
+}
+
+void gluPerspective(GLdouble fovy, GLdouble aspect, GLdouble zNear,
+                    GLdouble zFar) {
+}

--- a/samples/opengl/GL/glut.h
+++ b/samples/opengl/GL/glut.h
@@ -58,6 +58,10 @@ void glutInit(int* argc, char* argv[]) {
   pb_end(p);
 }
 
+void glutInitWindowSize(int width, int height) {
+  //FIXME: Possibly use this to pick default viewport or even display mode?
+}
+
 #define GLUT_DOUBLE 0x1
 #define GLUT_RGB 0x2
 #define GLUT_DEPTH 0x4

--- a/samples/opengl/GL/glut.h
+++ b/samples/opengl/GL/glut.h
@@ -1,0 +1,134 @@
+#include <hal/video.h>
+#include <hal/xbox.h>
+#include <math.h>
+#include <pbkit/pbkit.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <xboxkrnl/xboxkrnl.h>
+#include <xboxrt/debug.h>
+
+#include "gl.h"
+#include "glu.h"
+
+static void(*displayFunc)(void) = NULL;
+static void(*reshapeFunc)(int w, int h) = NULL;
+
+void glutInit(int* argc, char* argv[]) {
+
+  //FIXME: Do most of this in glutCreateWindow instead?
+
+  int status;
+  if ((status = pb_init())) {
+    debugPrint("pb_init Error %d\n", status);
+    XSleep(2000);
+    XReboot();
+    return;
+  }
+
+  pb_show_front_screen();
+
+#if 0
+  /* Basic setup */
+  width = pb_back_buffer_width();
+  height = pb_back_buffer_height();
+  glViewport(0, 0, width, height);
+#endif
+
+  // Setup fixed vertex processing
+#if 0
+    p = pb_begin();
+
+    /* Set execution mode */
+    pb_push1(p, NV097_SET_TRANSFORM_EXECUTION_MODE,
+        MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_MODE, NV097_SET_TRANSFORM_EXECUTION_MODE_MODE_PROGRAM)
+        | MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE, NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE_PRIV));
+    p += 2;
+
+    pb_end(p);
+#endif
+
+  // Setup register combiner
+  //FIXME: Emulate FFP or use https://www.khronos.org/registry/OpenGL/extensions/NV/NV_register_combiners.txt
+  uint32_t* p = pb_begin();
+  #include "../ps.inl"
+  pb_end(p);
+}
+
+#define GLUT_DOUBLE 0x1
+#define GLUT_RGB 0x2
+#define GLUT_DEPTH 0x4
+
+void glutInitDisplayMode(int flags) {
+  // Don't need this for now
+}
+
+void glutCreateWindow(const char* title) {
+  // We don't need a window on Xbox  
+}
+
+void glutDisplayFunc(void(*func)(void)) {
+  displayFunc = func;
+}
+
+void glutReshapeFunc(void(*func)(int w, int h)) {
+  reshapeFunc = func;  
+}
+
+//FIXME: Avoid waiting for vsync twice?
+void glutSwapBuffers(void) {
+  pb_wait_for_vbl();
+  pb_reset();
+  pb_target_back_buffer();
+
+  glFinish();
+}
+
+void glutMainLoop(void) {
+  // FIXME: this probably shouldn't have to call reshape, but we don't have save GL defaults
+  int width = pb_back_buffer_width();
+  int height = pb_back_buffer_height();
+  reshapeFunc(width, height);
+
+  int       start, last, now;
+  int       fps, frames, frames_total;
+
+
+  /* Setup to determine frames rendered every second */
+  start = now = last = XGetTickCount();
+  frames_total = frames = fps = 0;
+
+  while(true) {
+    displayFunc();
+
+#if 0
+  //FIXME: Draw window title?
+  pb_print("Frames: %d\n", frames_total);
+  if (fps > 0) {
+      pb_print("FPS: %d", fps);
+  }
+  pb_draw_text_screen();
+  pb_erase_text_screen();
+#endif
+
+    //FIXME: This is bad, we should be calling the idle func during this time instead!
+    glFinish();
+
+    frames++;
+    frames_total++;
+
+    /* Latch FPS counter every second */
+    now = XGetTickCount();
+    if ((now-last) > 1000) {
+        fps = frames;
+        frames = 0;
+        last = now;
+    }
+  }
+
+  pb_show_debug_screen();
+  pb_kill();
+}

--- a/samples/opengl/Makefile.cube
+++ b/samples/opengl/Makefile.cube
@@ -1,0 +1,6 @@
+XBE_TITLE = glut-cube
+GEN_XISO = $(XBE_TITLE).iso
+SRCS = $(CURDIR)/cube.c
+CFLAGS = -I$(CURDIR)
+NXDK_DIR = $(CURDIR)/../..
+include $(NXDK_DIR)/Makefile

--- a/samples/opengl/Makefile.simple
+++ b/samples/opengl/Makefile.simple
@@ -1,0 +1,6 @@
+XBE_TITLE = glut-simple
+GEN_XISO = $(XBE_TITLE).iso
+SRCS = $(CURDIR)/simple.c
+CFLAGS = -I$(CURDIR)
+NXDK_DIR = $(CURDIR)/../..
+include $(NXDK_DIR)/Makefile

--- a/samples/opengl/cube.c
+++ b/samples/opengl/cube.c
@@ -1,0 +1,96 @@
+/*
+ * Based GLUT sample with the following license:
+ *
+ *     Copyright (c) Mark J. Kilgard, 1997.
+ *
+ *     This program is freely distributable without licensing fees 
+ *     and is provided without guarantee or warrantee expressed or 
+ *     implied. This program is -not- in the public domain.
+ *
+ *
+ * This sample implements a tiny subset of the OpenGL API
+ */
+
+#include <GL/glut.h>
+
+GLfloat light_diffuse[] = {1.0, 0.0, 0.0, 1.0};  /* Red diffuse light. */
+GLfloat light_position[] = {1.0, 1.0, 1.0, 0.0};  /* Infinite light location. */
+GLfloat n[6][3] = {  /* Normals for the 6 faces of a cube. */
+  {-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {1.0, 0.0, 0.0},
+  {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 0.0, -1.0} };
+GLint faces[6][4] = {  /* Vertex indices for the 6 faces of a cube. */
+  {0, 1, 2, 3}, {3, 2, 6, 7}, {7, 6, 5, 4},
+  {4, 5, 1, 0}, {5, 6, 2, 1}, {7, 4, 0, 3} };
+GLfloat v[8][3];  /* Will be filled in with X,Y,Z vertexes. */
+
+void
+drawBox(void)
+{
+  int i;
+
+  for (i = 0; i < 6; i++) {
+    glBegin(GL_QUADS);
+    glNormal3fv(&n[i][0]);
+    glVertex3fv(&v[faces[i][0]][0]);
+    glVertex3fv(&v[faces[i][1]][0]);
+    glVertex3fv(&v[faces[i][2]][0]);
+    glVertex3fv(&v[faces[i][3]][0]);
+    glEnd();
+  }
+}
+
+void
+display(void)
+{
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  drawBox();
+  glutSwapBuffers();
+}
+
+void
+init(void)
+{
+  /* Setup cube vertex data. */
+  v[0][0] = v[1][0] = v[2][0] = v[3][0] = -1;
+  v[4][0] = v[5][0] = v[6][0] = v[7][0] = 1;
+  v[0][1] = v[1][1] = v[4][1] = v[5][1] = -1;
+  v[2][1] = v[3][1] = v[6][1] = v[7][1] = 1;
+  v[0][2] = v[3][2] = v[4][2] = v[7][2] = 1;
+  v[1][2] = v[2][2] = v[5][2] = v[6][2] = -1;
+
+  /* Enable a single OpenGL light. */
+  glLightfv(GL_LIGHT0, GL_DIFFUSE, light_diffuse);
+  glLightfv(GL_LIGHT0, GL_POSITION, light_position);
+  glEnable(GL_LIGHT0);
+  glEnable(GL_LIGHTING);
+
+  /* Use depth buffering for hidden surface elimination. */
+  glEnable(GL_DEPTH_TEST);
+
+  /* Setup the view of the cube. */
+  glMatrixMode(GL_PROJECTION);
+  gluPerspective( /* field of view in degree */ 40.0,
+    /* aspect ratio */ 1.0,
+    /* Z near */ 1.0, /* Z far */ 10.0);
+  glMatrixMode(GL_MODELVIEW);
+  gluLookAt(0.0, 0.0, 5.0,  /* eye is at (0,0,5) */
+    0.0, 0.0, 0.0,      /* center is at (0,0,0) */
+    0.0, 1.0, 0.);      /* up is in positive Y direction */
+
+  /* Adjust cube position to be asthetic angle. */
+  glTranslatef(0.0, 0.0, -1.0);
+  glRotatef(60, 1.0, 0.0, 0.0);
+  glRotatef(-20, 0.0, 0.0, 1.0);
+}
+
+int
+main(int argc, char **argv)
+{
+  glutInit(&argc, argv);
+  glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+  glutCreateWindow("red 3D lighted cube");
+  glutDisplayFunc(display);
+  init();
+  glutMainLoop();
+  return 0;             /* ANSI C requires main to return int. */
+}

--- a/samples/opengl/simple.c
+++ b/samples/opengl/simple.c
@@ -13,6 +13,20 @@
 
 #include <GL/glut.h>
 
+//#define INT
+
+#ifndef INT
+float lo = 200.0f;
+float hi = 400.0f;
+#define COL(x,y) glColor3f((x == lo) ? 0.0f : 1.0f, (y == lo) ? 0.0f: 1.0f, 0.0f)
+#define VERT(x,y) COL(x,y); glVertex3f(x, y, 0.0f)
+#else
+int lo = 0x2FFF;
+int hi = 0x7FFF;
+#define COL(x,y) glColor4ub((x == lo) ? 0x00 : 0xFF, (y == lo) ? 0x00 : 0xFF, 0x00, 0xFF)
+#define VERT(x,y) COL(x,y); glVertex2i(x, y)
+#endif
+
 void
 reshape(int w, int h)
 {
@@ -25,7 +39,8 @@ reshape(int w, int h)
   glViewport(0, 0, w, h);       /* Establish viewing area to cover entire window. */
   glMatrixMode(GL_PROJECTION);  /* Start modifying the projection matrix. */
   glLoadIdentity();             /* Reset project matrix. */
-  glOrtho(0, w, 0, h, -1, 1);   /* Map abstract coords directly to window coords. */
+//  glOrtho(0, w, 0, h, -1, 1);   /* Map abstract coords directly to window coords. */
+  glOrtho(0, 640, 0, 480, -1, 1);   /* Map abstract coords directly to window coords. */
 #if 0
   glScalef(1, -1, 1);           /* Invert Y axis so increasing Y goes down. */
   glTranslatef(0, -h, 0);       /* Shift origin up to upper-left corner. */
@@ -36,20 +51,40 @@ void
 display(void)
 {
   glClear(GL_COLOR_BUFFER_BIT);
+  glBegin(GL_QUADS);
+
+    glColor3f(0.0, 0.0, 0.0);  /* blue */
+    VERT(lo, lo);
+
+    glColor3f(1.0, 0.0, 0.0);  /* blue */
+    VERT(hi, lo);
+
+    glColor3f(1.0, 1.0, 0.0);  /* green */
+    VERT(hi, hi);
+
+    glColor3f(0.0, 1.0, 0.0);  /* red */
+    VERT(lo, hi);
+
+  glEnd();
+
+#if 0
   glBegin(GL_TRIANGLES);
 
-    glColor3f(0.0, 0.0, 1.0);  /* blue */
-    //glVertex2i(0, 0);
-    glVertex3f(0.0f, 0.0f, 0.0f);
-
-    glColor3f(0.0, 1.0, 0.0);  /* green */
-    //glVertex2i(200, 200);
-    glVertex3f(1.0f, 1.0f, 0.0f);
-
-    glColor3f(1.0, 0.0, 0.0);  /* red */
+    glColor3f(0.0, 1.0, 0.0);  /* red */
     //glVertex2i(20, 200);
-    glVertex3f(0.1f, 1.0f, 0.0f);
+    glVertex3f(lo, hi, 0.0f);
+
+    glColor3f(1.0, 1.0, 0.0);  /* green */
+    //glVertex2i(200, 200);
+    glVertex3f(hi, hi, 0.0f);
+
+    glColor3f(0.0, 0.0, 0.0);  /* blue */
+    //glVertex2i(0, 0);
+    glVertex3f(lo, lo, 0.0f);
+
   glEnd();
+#endif
+
   glFlush();  /* Single buffered, so needs a flush. */
 }
 

--- a/samples/opengl/simple.c
+++ b/samples/opengl/simple.c
@@ -1,0 +1,65 @@
+/*
+ * Based GLUT sample with the following license:
+ *
+ *     Copyright (c) Mark J. Kilgard, 1996.
+ *
+ *     This program is freely distributable without licensing fees 
+ *     and is provided without guarantee or warrantee expressed or 
+ *     implied. This program is -not- in the public domain.
+ *
+ *
+ * This sample implements a tiny subset of the OpenGL API
+ */
+
+#include <GL/glut.h>
+
+void
+reshape(int w, int h)
+{
+  /* Because Gil specified "screen coordinates" (presumably with an
+     upper-left origin), this short bit of code sets up the coordinate
+     system to correspond to actual window coodrinates.  This code
+     wouldn't be required if you chose a (more typical in 3D) abstract
+     coordinate system. */
+
+  glViewport(0, 0, w, h);       /* Establish viewing area to cover entire window. */
+  glMatrixMode(GL_PROJECTION);  /* Start modifying the projection matrix. */
+  glLoadIdentity();             /* Reset project matrix. */
+  glOrtho(0, w, 0, h, -1, 1);   /* Map abstract coords directly to window coords. */
+#if 0
+  glScalef(1, -1, 1);           /* Invert Y axis so increasing Y goes down. */
+  glTranslatef(0, -h, 0);       /* Shift origin up to upper-left corner. */
+#endif
+}
+
+void
+display(void)
+{
+  glClear(GL_COLOR_BUFFER_BIT);
+  glBegin(GL_TRIANGLES);
+
+    glColor3f(0.0, 0.0, 1.0);  /* blue */
+    //glVertex2i(0, 0);
+    glVertex3f(0.0f, 0.0f, 0.0f);
+
+    glColor3f(0.0, 1.0, 0.0);  /* green */
+    //glVertex2i(200, 200);
+    glVertex3f(1.0f, 1.0f, 0.0f);
+
+    glColor3f(1.0, 0.0, 0.0);  /* red */
+    //glVertex2i(20, 200);
+    glVertex3f(0.1f, 1.0f, 0.0f);
+  glEnd();
+  glFlush();  /* Single buffered, so needs a flush. */
+}
+
+int
+main(int argc, char **argv)
+{
+  glutInit(&argc, argv);
+  glutCreateWindow("single triangle");
+  glutDisplayFunc(display);
+  glutReshapeFunc(reshape);
+  glutMainLoop();
+  return 0;             /* ANSI C requires main to return int. */
+}

--- a/samples/opengl/simple.c
+++ b/samples/opengl/simple.c
@@ -21,10 +21,11 @@ float hi = 400.0f;
 #define COL(x,y) glColor3f((x == lo) ? 0.0f : 1.0f, (y == lo) ? 0.0f: 1.0f, 0.0f)
 #define VERT(x,y) COL(x,y); glVertex3f(x, y, 0.0f)
 #else
-int lo = 0x2FFF;
-int hi = 0x7FFF;
+//FIXME: This codepath is broken on Xbox because 2s does not work! See gl.h
+int lo = 200;
+int hi = 400;
 #define COL(x,y) glColor4ub((x == lo) ? 0x00 : 0xFF, (y == lo) ? 0x00 : 0xFF, 0x00, 0xFF)
-#define VERT(x,y) COL(x,y); glVertex2i(x, y)
+#define VERT(x,y) COL(x,y); glVertex2s(x, y)
 #endif
 
 void
@@ -40,11 +41,21 @@ reshape(int w, int h)
   glMatrixMode(GL_PROJECTION);  /* Start modifying the projection matrix. */
   glLoadIdentity();             /* Reset project matrix. */
 //  glOrtho(0, w, 0, h, -1, 1);   /* Map abstract coords directly to window coords. */
+
+
+
   glOrtho(0, 640, 0, 480, -1, 1);   /* Map abstract coords directly to window coords. */
+
 #if 0
   glScalef(1, -1, 1);           /* Invert Y axis so increasing Y goes down. */
   glTranslatef(0, -h, 0);       /* Shift origin up to upper-left corner. */
 #endif
+
+//  glTranslatef(0, 10.0f, 0);       /* Shift origin up to upper-left corner. */
+
+//  glScalef(1.5, 0.2, 1);           /* Invert Y axis so increasing Y goes down. */
+
+
 }
 
 void
@@ -92,6 +103,7 @@ int
 main(int argc, char **argv)
 {
   glutInit(&argc, argv);
+  glutInitWindowSize(640, 480);
   glutCreateWindow("single triangle");
   glutDisplayFunc(display);
   glutReshapeFunc(reshape);


### PR DESCRIPTION
# I don't have any plans to actively work on this.
##  This is mostly to get people started and interested in the idea. Please leave a comment below if you want to continue work on this.

The goal is to support [simple.c and cube.c](https://www.opengl.org/archives/resources/code/samples/glut_examples/examples/examples.html):

![Goal simple.c](https://www.opengl.org/archives/resources/code/samples/glut_examples/examples/simple.jpg) ![Goal cube.c](https://www.opengl.org/archives/resources/code/samples/glut_examples/examples/cube.jpg)

Eventually the long term goal is to also support dinoshade.c

---

Here is what works (simple.c):

![Running in XQEMU](https://user-images.githubusercontent.com/360330/42725767-a5f0bf2c-8789-11e8-9c46-5809b31a3234.png)


Make using `make -f Makefile.simple` or `make -f Makefile.cube` (untested)

---

A motivation for this is to have unit tests for 2 XQEMU issues, and to have a nice API to generate pushbuffer streams.

---

TODO:
- Fix transforms so this sample works (attributes have been confirmed to be correct)
- Fix GL matrix operations so this sample looks correct
- Add proper licensing information for MESA code
- Test on hardware (Also see existing issue with "triangle" sample of nxdk on real hardware)
- Cleanup use of GL and create issue about adding a state machine