### PR TITLE
Hacks to make nxdk better suited for xbe-loader

### DIFF
--- a/lib/hal/fileio.c
+++ b/lib/hal/fileio.c
@@ -93,6 +93,12 @@ int XConvertDOSFilenameToXBOX(char *dosFilename, char *xboxFilename)
 	// directory without the leading slash.  eg. "foo\bar.txt"
 	char *path;
 
+  // Hack to also accept Xbox names directly
+  if (!memcmp(dosFilename, "\\Device\\", 8)) {
+    strcpy(xboxFilename, dosFilename);
+  	return STATUS_SUCCESS;
+  }
+
 	// partition points to a literal string representing
 	// the fully qualified device name
 	char *partition = NULL;

--- a/lib/net/pktdrv/pktdrv.c
+++ b/lib/net/pktdrv/pktdrv.c
@@ -42,6 +42,9 @@
 extern unsigned long times(void *);
 
 //temporary dirty interface
+void* PktdrvMmioBase = (void*)0xFEF00000;
+unsigned int PktdrvInterrupt = 4;
+
 extern int something_to_send;
 extern unsigned char *packet_to_send;
 extern unsigned int size_of_packet_to_send;
@@ -342,10 +345,9 @@ enum {
 
 
 //Register access macros for XBOX
-#define	BASE	0xFEF00000
-#define REG(x)	(*((DWORD *)(BASE+(x))))
-#define REGW(x)	(*((WORD *)(BASE+(x))))
-#define REGB(x)	(*((BYTE *)(BASE+(x))))
+#define REG(x)	(*((DWORD *)((ULONG_PTR)PktdrvMmioBase+(x))))
+#define REGW(x)	(*((WORD *)((ULONG_PTR)PktdrvMmioBase+(x))))
+#define REGB(x)	(*((BYTE *)((ULONG_PTR)PktdrvMmioBase+(x))))
 
 
 
@@ -644,6 +646,7 @@ static void PktdrvMiiInterrupt(int mode)
 
 static BOOLEAN __stdcall MyPktdrvIsr(PKINTERRUPT Interrupt, PVOID ServiceContext)
 {
+  debugPrint("In MyPktdrvIsr\n");
 	REG(NvRegIrqMask)=0;
 	if (g_running)
 	{
@@ -742,7 +745,8 @@ int Pktdrv_Init(void)
 	}
 	
 
-	g_s->Vector=HalGetInterruptVector(4,&g_s->IrqLevel); 
+	g_s->Vector=HalGetInterruptVector(PktdrvInterrupt,&g_s->IrqLevel); 
+  debugPrint("Interrupt vector is 0x%x\n", g_s->Vector);
 	
 	KeInitializeDpc(&g_s->MyPktdrvDpcObject,&MyPktdrvDpc,&g_s->MyContext); 
 

--- a/lib/net/pktdrv/pktdrv.h
+++ b/lib/net/pktdrv/pktdrv.h
@@ -1,6 +1,9 @@
 #ifndef _Pktdrv_
 #define _Pktdrv_
 
+extern void* PktdrvMmioBase;
+extern unsigned int PktdrvInterrupt;
+
 int Pktdrv_Init(void);
 void Pktdrv_Quit(void);
 int Pktdrv_ReceivePackets(void);

--- a/lib/xboxrt/startup.c
+++ b/lib/xboxrt/startup.c
@@ -4,7 +4,7 @@
 extern void main(void);
 
 void XboxCRT(void) {
-    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+    //XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
 
     main();
 


### PR DESCRIPTION
We should probably support constructors and split our stdlib into actual libs.
Then it's easier to cherry-pick stuff we need to reduce memory footprint and allow bare metal work.

This depends on the upstream fixes.