### PR TITLE
Hacks for pbkit (for OpenSWE1R)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,13 +133,13 @@ main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ CG       ] $@"
 	$(VE) $(CGC) -profile vp20 -o $@.$$$$ $< $(QUIET) && \
 	$(VP20COMPILER) $@.$$$$ > $@ && \
-	rm -rf $@.$$$$
+	true #rm -rf $@.$$$$
 
 %.inl: %.ps.cg $(FP20COMPILER)
 	@echo "[ CG       ] $@"
 	$(VE) $(CGC) -profile fp20 -o $@.$$$$ $< $(QUIET) && \
 	$(FP20COMPILER) $@.$$$$ > $@ && \
-	rm -rf $@.$$$$
+	true #rm -rf $@.$$$$
 
 tools: $(TOOLS)
 .PHONY: tools $(TOOLS)

--- a/samples/triangle/main.c
+++ b/samples/triangle/main.c
@@ -108,6 +108,8 @@ void main(void)
         pb_end(p);
         p = pb_begin();
 
+  pb_push2(p,NV20_TCL_PRIMITIVE_3D_POLYGON_MODE_FRONT,0x1B01,0x1B01); p+=3; //FillMode="solid" BackFillMode="point"
+
         /* Clear all attributes */
         pb_push(p++, NV097_SET_VERTEX_DATA_ARRAY_FORMAT,16);
         for(i = 0; i < 16; i++) {
@@ -117,11 +119,11 @@ void main(void)
 
         /* Set vertex position attribute */
         set_attrib_pointer(0, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
-                           3, sizeof(ColoredVertex), &alloc_vertices[0]);
+                           3, sizeof(ColoredVertex), MmGetPhysicalAddress(&alloc_vertices[0]));
 
         /* Set vertex diffuse color attribute */
         set_attrib_pointer(3, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
-                           3, sizeof(ColoredVertex), &alloc_vertices[3]);
+                           3, sizeof(ColoredVertex), MmGetPhysicalAddress(&alloc_vertices[3]));
 
         /* Begin drawing triangles */
         draw_arrays(NV097_SET_BEGIN_END_OP_TRIANGLES, 0, num_vertices);

--- a/samples/triangle/vs.vs.cg
+++ b/samples/triangle/vs.vs.cg
@@ -17,7 +17,7 @@ vOut main(
 	float4 position;
 
 	position = mul(float4(I.position.xyz, 1.0f), m_viewport);
-	position.xyz = position.xyz / position.w;
+	//position.xyz = position.xyz / position.w;
 
 	result.col = I.color;
 	result.pos = position;


### PR DESCRIPTION
Probably not necessary for OpenSWE1R - this was just prototyping.

Stuff that was prototyped here:

- [x] ~~Keeping shader files around (so the constant offsets are known)~~ has upstream issue [RC] and PR [VP]
- [x] ~~Avoid triple-buffering (not sure if working)~~ has upstream issue
- [x] ~~Support 16bpp mode (not working I think)~~ has upstream issue
- [ ] Physical addresses for GPU registers (bugfix?)
- [x] ~~Testing wireframe in triangle~~ hack only, working
- [x] ~~Checking behaviour of clipping in triangle (w = 1.0 assumed)~~ hack only, working

*Checked features are understood and can be removed; the rest should get a working and proper solution or issue upstream*