### PR TITLE
Networking: Semaphore and event (+ more)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,6 @@
 [submodule "lib/sdl/SDL_ttf"]
 	path = lib/sdl/SDL_ttf
 	url = https://github.com/SDL-mirror/SDL_ttf
+[submodule "samples/textures/nxdk-rdt"]
+	path = samples/textures/nxdk-rdt
+	url = https://github.com/XboxDev/nxdk-rdt.git

--- a/Makefile
+++ b/Makefile
@@ -133,13 +133,13 @@ main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ CG       ] $@"
 	$(VE) $(CGC) -profile vp20 -o $@.$$$$ $< $(QUIET) && \
 	$(VP20COMPILER) $@.$$$$ > $@ && \
-	rm -rf $@.$$$$
+	true # rm -rf $@.$$$$
 
 %.inl: %.ps.cg $(FP20COMPILER)
 	@echo "[ CG       ] $@"
 	$(VE) $(CGC) -profile fp20 -o $@.$$$$ $< $(QUIET) && \
 	$(FP20COMPILER) $@.$$$$ > $@ && \
-	rm -rf $@.$$$$
+	true; #rm -rf $@.$$$$
 
 tools: $(TOOLS)
 .PHONY: tools $(TOOLS)

--- a/samples/textures/Makefile
+++ b/samples/textures/Makefile
@@ -5,4 +5,33 @@ GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 SHADER_OBJS = ps.inl vs.inl
 
+
+
+
+# The following is from nxdk-rdt, but adapted
+
+NXDK_NET = y
+
+GEN_XISO = $(XBE_TITLE).iso
+
+SRCS += $(CURDIR)/nxdk-rdt/net.c
+SRCS += $(CURDIR)/nxdk-rdt/dbgd.c
+SRCS += $(CURDIR)/nxdk-rdt/lib/protobuf-c/protobuf-c.c
+SRCS += $(CURDIR)/nxdk-rdt/dbg.pb-c.c
+
+CFLAGS += -I$(CURDIR)/
+CFLAGS += -I$(CURDIR)/nxdk-rdt/lib
+
+all_local: all
+
 include $(NXDK_DIR)/Makefile
+
+#FIXME: Needs to be in different dir
+#.PHONY:clean_local
+#clean_local:
+#	rm -f *.inl* log.txt dump.cap main.lib *.pb-c.c *.pb-c.h *_pb2.py
+
+#clean: clean_local
+
+$(CURDIR)/nxdk-rdt/%.pb-c.c $(CURDIR)/nxdk-rdt/%.pb-c.h: nxdk-rdt/%.proto
+	protoc-c --c_out=$(CURDIR)/ "$<"

--- a/samples/textures/Makefile
+++ b/samples/textures/Makefile
@@ -1,0 +1,8 @@
+NXDK_DIR = $(CURDIR)/../..
+
+XBE_TITLE = textures
+GEN_XISO = $(XBE_TITLE).iso
+SRCS = $(CURDIR)/main.c
+SHADER_OBJS = ps.inl vs.inl
+
+include $(NXDK_DIR)/Makefile

--- a/samples/textures/main.c
+++ b/samples/textures/main.c
@@ -17,6 +17,9 @@
 
 #include <xboxkrnl/xboxkrnl.h>
 
+#include "nxdk-rdt/net.h"
+#include "nxdk-rdt/dbgd.h"
+
 #define BUTTON_DEADZONE 0x20
 
 static uint32_t *alloc_vertices;
@@ -124,6 +127,11 @@ void main(void) {
   debugPrint("Setting video mode\n");
 
   XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+
+  debugPrint("Initializing nxdk-rdt\n");
+
+  net_init();
+  dbgd_init();
 
   debugPrint("Initializing pbkit\n");
 

--- a/samples/textures/main.c
+++ b/samples/textures/main.c
@@ -1,0 +1,334 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <assert.h>
+#include <math.h>
+
+#include <hal/input.h>
+#include <hal/video.h>
+#include <hal/xbox.h>
+
+#include <xboxrt/debug.h>
+
+#include <pbkit/pbkit.h>
+
+#include <xboxkrnl/xboxkrnl.h>
+
+#define BUTTON_DEADZONE 0x20
+
+static uint32_t *alloc_vertices;
+static uint32_t  num_vertices;
+
+typedef struct {
+  float pos[3];
+  float uv[2];
+} __attribute__((packed)) Vertex;
+
+static const Vertex vertices[] = {
+  //  X     Y     Z       U     V
+  {{ -1.0,  1.0, 1.0 }, { 0.0, 0.0 }}, 
+  {{  1.0,  1.0, 1.0 }, { 1.0, 0.0 }}, 
+  {{  1.0, -1.0, 1.0 }, { 1.0, 1.0 }}, 
+  {{ -1.0, -1.0, 1.0 }, { 0.0, 1.0 }}
+};
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+#define MASK(mask, val) (((val) << (ffs(mask)-1)) & (mask))
+
+static void matrix_viewport(float out[4][4], float x, float y, float width, float height, float z_min, float z_max) {
+  memset(out, 0, 4*4*sizeof(float));
+  out[0][0] = width/2.0f;
+  out[1][1] = height/-2.0f;
+  out[2][2] = z_max - z_min;
+  out[3][3] = 1.0f;
+  out[3][0] = x + width/2.0f;
+  out[3][1] = y + height/2.0f;
+  out[3][2] = z_min;
+}
+
+static void init_shader(void) {
+  uint32_t *p;
+
+  // Setup vertex shader
+  uint32_t vs_program[] = {
+#include "vs.inl"
+  };
+
+  p = pb_begin();
+
+  // Set run address of shader
+  pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_START, 0);
+  p += 2;
+
+  // Set execution mode
+  pb_push1(p, NV097_SET_TRANSFORM_EXECUTION_MODE, 
+      MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_MODE, NV097_SET_TRANSFORM_EXECUTION_MODE_MODE_PROGRAM)
+      | MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE, NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE_PRIV));
+  p += 2;
+
+  pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_CXT_WRITE_EN, 0);
+  p += 2;
+
+  // Set cursor and begin copying program
+  pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_LOAD, 0);
+  p += 2;
+
+  for (int i = 0; i < sizeof(vs_program) / 8; i++) {
+    pb_push(p++, NV097_SET_TRANSFORM_PROGRAM, 4);
+    memcpy(p, &vs_program[i*4], 4*4);
+    p+=4;
+  }
+
+  pb_end(p);
+
+  // Setup fragment shader
+  p = pb_begin();
+//FIXME: Set up manually
+#include "ps.inl"
+  pb_end(p);
+}
+
+static void set_attrib_pointer(unsigned int index, unsigned int format, unsigned int size, unsigned int stride, const void* data) {
+  uint32_t *p = pb_begin();
+  pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_FORMAT + index*4, 
+      MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE, format) | \
+      MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_SIZE, size) | \
+      MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_STRIDE, stride));
+  p += 2;
+  pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_OFFSET + index*4, (uint32_t)data & 0x03ffffff);
+  p += 2;
+  pb_end(p);
+}
+
+static void draw_arrays(unsigned int mode, int start, int count) {
+  uint32_t *p = pb_begin();
+  pb_push1(p, NV097_SET_BEGIN_END, mode); p += 2;
+
+  pb_push(p++, 0x40000000 | NV097_DRAW_ARRAYS, 1); //bit 30 means all params go to same register 0x1810
+  *(p++) = MASK(NV097_DRAW_ARRAYS_COUNT, (count-1)) | MASK(NV097_DRAW_ARRAYS_START_INDEX, start);
+
+  // Due to bad design in pbkit, we can't return to pb_push1 after pb_push
+  // As a workaround, we use pb_push
+  pb_push(p++, NV097_SET_BEGIN_END, 1);
+  *(p++) = NV097_SET_BEGIN_END_OP_END;
+
+  pb_end(p);
+}
+
+void main(void) {
+  uint32_t *p;
+
+  debugPrint("Setting video mode\n");
+
+  XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+
+  debugPrint("Initializing pbkit\n");
+
+  int status = pb_init();
+  if (status != 0) {
+    debugPrint("pb_init Error %d\n", status);
+    XSleep(2000);
+    XReboot();
+    return;
+  }
+
+  pb_show_front_screen();
+
+  // Initialize input
+  XInput_Init();
+
+  // Basic setup
+  unsigned int width = pb_back_buffer_width();
+  unsigned int height = pb_back_buffer_height();
+
+  // Load constant rendering things (shaders, geometry)
+  init_shader();
+  alloc_vertices = MmAllocateContiguousMemoryEx(sizeof(vertices), 0, 0x3ffb000, 0, 0x404);
+  memcpy(alloc_vertices, vertices, sizeof(vertices));
+  num_vertices = ARRAY_SIZE(vertices);
+
+  //Generate a texture
+  int texture_width = 256;
+  int texture_height = 256;
+  int texture_pitch = texture_width * 4;
+  uint32_t* pixels = NULL;
+  pixels = MmAllocateContiguousMemoryEx(texture_pitch * texture_height, 0, 0x3ffb000, 0, 0x404);
+  for(int y = 0; y < texture_height; y++) {
+    for(int x = 0; x < texture_width; x++) {
+      uint32_t color = 0;
+      color = 0x00000000 | (x << 16) | (y << 8);
+
+      //FIXME: Checkerboard is interesting to see interpolation
+      //color = ((x + (y & 8)) & 8) ? 0xFFFFFFFF : 0xFF0000FF;
+
+      pixels[y * texture_width + x] = color;
+    }
+  }
+
+  while(1) {
+    pb_wait_for_vbl();
+    pb_reset();
+    pb_target_back_buffer();
+
+    // Clear depth & stencil buffers
+    pb_erase_depth_stencil_buffer(0, 0, width, height);
+    pb_fill(0, 0, width, height, 0x33333333);
+    pb_erase_text_screen();
+
+    //FIXME: WHY?!
+    while(pb_busy()) {
+      // Wait for completion...
+    }
+
+    // Check for input
+    XInput_GetEvents();
+
+    // Prepare new matrix
+    float viewport[4][4];
+    matrix_viewport(viewport, 0, 0, width, height, 0, 65536.0f);
+
+    // A bias added to texture values
+    float color_scale = 0.0f;
+    float color_bias = 0.0f;
+    float texture_scale[2] = { texture_width, texture_height };
+    float texture_bias[2] = { 0.0f, 0.0f };
+
+    // Send shader constants (must match locations from *.inl files)
+    p = pb_begin();
+
+    // Set shader constants cursor at c0
+    pb_push1(p, NV097_SET_TRANSFORM_CONSTANT_LOAD, 96); p+=2;
+
+    // Send the transformation matrix
+    float c[][4] = {
+      { viewport[0][0], viewport[0][1], viewport[0][2], viewport[0][3] }, // c0
+      { viewport[1][0], viewport[1][1], viewport[1][2], viewport[1][3] }, // c1
+      { viewport[2][0], viewport[2][1], viewport[2][2], viewport[2][3] }, // c2
+      { viewport[3][0], viewport[3][1], viewport[3][2], viewport[3][3] }, // c3
+      { texture_scale[0], texture_scale[1], 0.0f, 0.0f },                 // c4
+      { texture_bias[0],  texture_bias[1],  0.0f, 0.0f }                  // c5
+    };
+    int float_count = ARRAY_SIZE(c) * 4;
+    assert(float_count % 4 == 0);
+    pb_push(p++, NV097_SET_TRANSFORM_CONSTANT, float_count);
+    memcpy(p, c, float_count * 4); p+=float_count;
+
+    // Set constants for combiner stages
+    //FIXME: var float4 scale :  : COMBINER_STAGE_CONST0[0] : 1 : 1
+    //FIXME: var float4 bias :  : COMBINER_STAGE_CONST1[0] : 2 : 1
+
+    pb_end(p);
+
+    // Set up texture
+    p=pb_begin();
+
+    int texture_fmt = NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_B8G8R8A8;
+    texture_fmt = 0x12;
+    pb_push2(p,NV20_TCL_PRIMITIVE_3D_TX_OFFSET(0),(DWORD)(MmGetPhysicalAddress(pixels) & 0x03ffffff), (0x0001002a | (texture_fmt << 8))); p+=3; //set stage 0 texture address & format
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_NPOT_PITCH(0),texture_pitch<<16); p+=2; //set stage 0 texture pitch (pitch<<16)
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_NPOT_SIZE(0),(texture_width<<16)|texture_height); p+=2; //set stage 0 texture width & height ((witdh<<16)|height)
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(0),0x00030303); p+=2;//set stage 0 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(0),0x4003ffc0); p+=2; //set stage 0 texture enable flags
+
+    //FIXME: Set up signed stuff
+    bool texture_signed[4] = { false, true, false, false };
+
+    // Use button color for assignments
+    texture_signed[0] = (g_Pads[0].CurrentButtons.ucAnalogButtons[XPAD_B] > BUTTON_DEADZONE);
+    texture_signed[1] = (g_Pads[0].CurrentButtons.ucAnalogButtons[XPAD_A] > BUTTON_DEADZONE);
+    texture_signed[2] = (g_Pads[0].CurrentButtons.ucAnalogButtons[XPAD_X] > BUTTON_DEADZONE);
+    texture_signed[3] = (g_Pads[0].CurrentButtons.ucAnalogButtons[XPAD_Y] > BUTTON_DEADZONE);
+
+#   define NV_PGRAPH_TEXFILTER0_ASIGNED                         (1 << 28)
+#   define NV_PGRAPH_TEXFILTER0_RSIGNED                         (1 << 29)
+#   define NV_PGRAPH_TEXFILTER0_GSIGNED                         (1 << 30)
+#   define NV_PGRAPH_TEXFILTER0_BSIGNED                         (1 << 31)
+
+    uint32_t texture_filter = 0x04074000;
+    if (texture_signed[0]) { texture_filter |= NV_PGRAPH_TEXFILTER0_RSIGNED; }
+    if (texture_signed[1]) { texture_filter |= NV_PGRAPH_TEXFILTER0_GSIGNED; }
+    if (texture_signed[2]) { texture_filter |= NV_PGRAPH_TEXFILTER0_BSIGNED; }
+    if (texture_signed[3]) { texture_filter |= NV_PGRAPH_TEXFILTER0_ASIGNED; }
+
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(0), texture_filter); p+=2; //set stage 0 texture filters (AA!)
+
+    pb_end(p);
+
+    // Disable other texture stages
+    p=pb_begin();
+
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(1),0x0003ffc0); p+=2;//set stage 1 texture enable flags (bit30 disabled)
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(1),0x00030303); p+=2;//set stage 1 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(1),0x02022000); p+=2;//set stage 1 texture filters (no AA, stage not even used)
+
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(2),0x0003ffc0); p+=2;//set stage 2 texture enable flags (bit30 disabled)
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(2),0x00030303); p+=2;//set stage 2 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(2),0x02022000); p+=2;//set stage 2 texture filters (no AA, stage not even used)
+
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(3),0x0003ffc0); p+=2;//set stage 3 texture enable flags (bit30 disabled)
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(3),0x00030303); p+=2;//set stage 3 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
+    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(3),0x02022000); p+=2;//set stage 3 texture filters (no AA, stage not even used)
+
+    pb_end(p);
+
+    // Reset vertex attributes
+    p = pb_begin();
+
+    // Clear all attributes
+    pb_push(p++, NV097_SET_VERTEX_DATA_ARRAY_FORMAT, 16);
+    for(int i = 0; i < 16; i++) {
+      *(p++) = NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F;
+    }
+
+    pb_end(p);
+
+    // Set vertex position attribute
+    set_attrib_pointer(0, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F, 
+                       3, sizeof(Vertex), &alloc_vertices[0]);
+
+    // Set vertex uv attribute
+    set_attrib_pointer(8, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F, 
+                       2, sizeof(Vertex), &alloc_vertices[3]);
+
+    // Begin drawing quad
+    draw_arrays(NV097_SET_BEGIN_END_OP_QUADS, 0, num_vertices);
+
+    // Draw some text on the screen
+    pb_print("Textures\n");
+    pb_print("random: %d\n", rand());
+    char signed_text[5];
+    strcpy(signed_text, "    ");
+    if (texture_signed[0]) { signed_text[0] = 'R'; };
+    if (texture_signed[1]) { signed_text[1] = 'G'; };
+    if (texture_signed[2]) { signed_text[2] = 'B'; };
+    if (texture_signed[3]) { signed_text[3] = 'A'; };
+    pb_print("signed: '%s'\n", signed_text);
+    pb_print("pad: %d %d\n", g_Pads[0].sLThumbX,
+                             g_Pads[0].sLThumbY);
+
+    //FIXME: Print current object-size
+    //FIXME: Print current texture-size
+    //FIXME: Print current signedness
+    //FIXME: Print current texture format
+
+    pb_draw_text_screen();
+
+    while(pb_busy()) {
+      // Wait for completion...
+    }
+
+    // Swap buffers (if we can)
+    while (pb_finished()) {
+      // Not ready to swap yet
+    }
+  }
+
+  // Unreachable cleanup code
+  MmFreeContiguousMemory(alloc_vertices);
+  pb_show_debug_screen();
+  pb_kill();
+  HalReturnToFirmware(HalQuickRebootRoutine);
+}

--- a/samples/textures/main.c
+++ b/samples/textures/main.c
@@ -144,6 +144,9 @@ void main(void) {
   }
 
   pb_show_front_screen();
+  pb_show_debug_screen(); //FIXME: Remove.. hack..
+
+while(1);
 
   // Initialize input
   XInput_Init();

--- a/samples/textures/ps.ps.cg
+++ b/samples/textures/ps.ps.cg
@@ -1,0 +1,13 @@
+struct vOut {
+  float2 uv : TEXCOORD0;
+};
+
+float4 main(
+  vOut I,
+  uniform float4 color_scale,
+  uniform float4 color_bias,
+  uniform sampler2D texture
+) : COLOR
+{
+  return 0.5 + 0.5 * tex2D(texture, I.uv); //FIXME: * color_scale + color_bias;
+}

--- a/samples/textures/vs.vs.cg
+++ b/samples/textures/vs.vs.cg
@@ -1,0 +1,26 @@
+struct vIn {
+  float4 position : POSITION;
+  float2 uv       : TEXCOORD0;
+};
+
+struct vOut {
+  float4 pos : POSITION;
+  float2 uv  : TEXCOORD0;
+};
+
+vOut main(
+  vIn              I,
+  uniform float4x4 viewport,
+  uniform float2 texture_scale,
+  uniform float2 texture_bias
+) {
+  vOut   result;
+  float4 position;
+
+  position = mul(float4(I.position.xyz, 1.0f), viewport);
+  position.xyz = position.xyz / position.w;
+
+  result.pos = position;
+  result.uv = I.uv * texture_scale + texture_bias;
+  return result;
+}


### PR DESCRIPTION
Prototype / bug search.

- **The semaphore commit is broken**
- The event stuff is unclean
- The stack of the receiver thread sucks (should be way smaller)
- Still requires context switching before receiving data
- Allocation fix should be isolated
- Length fix should be isolated
- Performance still bad: xboxpy uses 256 byte chunks because nxdk-rdt netcode is bad

Accidentally based on #13 , but well suited for testing, too.