### PR TITLE
pbkit 16bpp surfaces

### DIFF
--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -2019,7 +2019,7 @@ void pb_target_extra_buffer(int index_buffer)
         //DMA channel 10 is used by GPU in order to render depth stencil
         if (depth_stencil)
         {
-            dma_addr=pb_DSAddr&0x03FFFFFF;
+            dma_addr=0;//pb_DSAddr&0x03FFFFFF;
             dma_limit=height*pitch_depth_stencil-1; //(last byte)
             dma_flags=DMA_CLASS_3D|0x0000B000;
             dma_addr|=3;
@@ -2048,7 +2048,7 @@ void pb_target_extra_buffer(int index_buffer)
         pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT4,10); p+=2;
         pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_TEST_ENABLE,flag); p+=2; //ZEnable=TRUE or FALSE (But don't use W, see below)
         //FIXME: Disable
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_ENABLE,1); p+=2;   //StencilEnable=TRUE
+        pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_ENABLE,0); p+=2;   //StencilEnable=TRUE
         pb_end(p);
 
         pb_DepthStencilLast=depth_stencil;

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -1899,7 +1899,7 @@ void pb_target_back_buffer(void)
         if (depth_stencil)
         {
             dma_addr=pb_DSAddr&0x03FFFFFF;
-            dma_limit=height*pitch_depth_stencil-1; //(last byte)
+            dma_limit=64 * 1024 * 1024 - INSTANCE_MEM_MAXSIZE - 1; //height*pitch_depth_stencil-1; //(last byte)
             dma_flags=DMA_CLASS_3D|0x0000B000;
             dma_addr|=3;
             flag=1;
@@ -2179,7 +2179,7 @@ unsigned int pb_ColorBpp = 0;
 unsigned int pb_ZetaBpp = 32; //FIXME: ?
 int pb_ZetaFixed = 0; //FIXME: bool?
 
-void pb_set_zeta_depth(unsigned int bpp, int fixed)
+void pb_set_zeta_format(unsigned int bpp, int fixed)
 {
     pb_ZetaBpp = bpp;
 
@@ -2493,12 +2493,6 @@ void pb_show_front_screen(void)
 void pb_show_debug_screen(void)
 {
     VIDEOREG(PCRTC_START)=((DWORD)XVideoGetFB())&0x0FFFFFFF;
-    pb_debug_screen_active=1;
-}
-
-void pb_show_depth_screen(void)
-{
-    VIDEOREG(PCRTC_START)=pb_DSAddr&0x0FFFFFFF;
     pb_debug_screen_active=1;
 }
 
@@ -3603,7 +3597,6 @@ int pb_init(void)
     //(not necessarily the size of a pixel line, because of hardware optimization)
 
     Pitch=(((pb_ZetaBpp*HSize)>>3)+0x3F)&0xFFFFFFC0; //64 units aligned
-    pb_DepthStencilPitch=Pitch;
 
     //look for a standard listed pitch value greater or equal to theoretical one
     for(i=0;i<16;i++)
@@ -3614,6 +3607,8 @@ int pb_init(void)
             break;
         }
     }
+
+    pb_DepthStencilPitch=Pitch;
 
     Size=Pitch*VSize;
 
@@ -3651,7 +3646,7 @@ int pb_init(void)
             Pitch,              //DWORD tile_pitch,
             0,              //DWORD tile_z_start_tag,
             0,              //DWORD tile_z_offset,
-            tile_flags          //DWORD tile_flags (0x04000000 for 32 bits)
+            tile_flags          //DWORD tile_flags
             );
 
 

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -1926,6 +1926,7 @@ void pb_target_back_buffer(void)
         pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
         pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT4,10); p+=2;
         pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_TEST_ENABLE,flag); p+=2; //ZEnable=TRUE or FALSE (But don't use W, see below)
+        //FIXME: Disable
         pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_ENABLE,1); p+=2;   //StencilEnable=TRUE
         pb_end(p);
 
@@ -2046,6 +2047,7 @@ void pb_target_extra_buffer(int index_buffer)
         pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
         pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT4,10); p+=2;
         pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_TEST_ENABLE,flag); p+=2; //ZEnable=TRUE or FALSE (But don't use W, see below)
+        //FIXME: Disable
         pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_ENABLE,1); p+=2;   //StencilEnable=TRUE
         pb_end(p);
 
@@ -2171,6 +2173,18 @@ void pb_extra_buffers(int n)
         debugPrint("Too many extra buffers\n");
     else
         pb_ExtraBuffersCount=n;
+}
+
+unsigned int pb_ColorBpp = 0;
+unsigned int pb_ZetaBpp = 32; //FIXME: ?
+int pb_ZetaFixed = 0; //FIXME: bool?
+
+void pb_set_zeta_depth(unsigned int bpp, int fixed)
+{
+    pb_ZetaBpp = bpp;
+
+    //FIXME: Add support or warn
+    pb_ZetaFixed = fixed;
 }
 
 void pb_size(DWORD size)
@@ -2545,8 +2559,10 @@ void pb_fill(int x, int y, int w, int h, DWORD color)
     x2=x+w;
     y2=y+h;
     
-    //if you supply 32 bits color and res is 16 bits, apply function below
-    //color=((color>>8)&0xF800)|((color>>5)&0x07E0)|((color>>3)&0x001F);
+    if (pb_ColorBpp == 16) {
+      //if you supply 32 bits color and res is 16 bits, apply transformation
+      color=((color>>8)&0xF800)|((color>>5)&0x07E0)|((color>>3)&0x001F);
+    }
 
     p=pb_begin();
     pb_push(p++,NV20_TCL_PRIMITIVE_3D_CLEAR_VALUE_HORIZ,2);     //sets rectangle coordinates
@@ -2579,14 +2595,25 @@ void pb_erase_depth_stencil_buffer(int x, int y, int w, int h)
     x2=x+w;
     y2=y+h;
     
+    DWORD z_clear_value = (DWORD)pb_ZScale;
+    BYTE stencil_clear_value = 0x00;
+
     p=pb_begin();
     pb_push(p++,NV20_TCL_PRIMITIVE_3D_CLEAR_VALUE_HORIZ,2);     //sets rectangle coordinates
     *(p++)=((x2-1)<<16)|x1;
     *(p++)=((y2-1)<<16)|y1;
     pb_push(p++,NV20_TCL_PRIMITIVE_3D_CLEAR_VALUE_DEPTH,3);     //sets data used to fill in rectangle
-    *(p++)=0xffffff00;      //(depth<<8)|stencil
+    if (pb_ZetaBpp == 32) {
+      *(p++)=(z_clear_value << 8) | stencil_clear_value;
+    } else {
+      *(p++)=z_clear_value & 0xFFFF;
+    }
     *(p++)=0;           //color
-    *(p++)=0x03;            //triggers the HW rectangle fill (only on D&S)
+    if (pb_ZetaBpp == 32) {
+      *(p++)=0x2 | 0x1;      //triggers the HW rectangle fill (only on S&D)
+    } else {
+      *(p++)=0x1;            //triggers the HW rectangle fill (only on D)
+    }
     pb_end(p);
 }
 
@@ -3450,9 +3477,35 @@ int pb_init(void)
     pb_DepthStencilLast=-2;
 
     vm=XVideoGetMode();
-    if (vm.bpp==32) pb_GPUFrameBuffersFormat=0x128;//A8R8G8B8
-    else pb_GPUFrameBuffersFormat=0x113;        //R5G6B5 (0x123 if D24S8 used, bpp 16 untested)
-    pb_ZScale=16777215.0f;              //D24S8
+    pb_ColorBpp = vm.bpp;
+
+    unsigned int depth_format;
+    if (pb_ZetaBpp == 32) {
+        //D24S8
+        depth_format = 0x2;
+        pb_ZScale = (float)0xFFFFFF;
+    } else if (pb_ZetaBpp == 16) {
+        // D16
+        depth_format = 0x1;
+        pb_ZScale = (float)0xFFFF;
+    } else {
+        //FIXME: Error
+    }
+
+    unsigned int color_format;
+    if (vm.bpp == 32) {
+        //A8R8G8B8
+        color_format = 0x8;
+    } else if (vm.bpp == 16) {
+        //R5G6B5
+        color_format = 0x3;
+    } else {
+        //FIXME: Error
+    }
+
+    // Activate pitched surface with chosen format
+    pb_GPUFrameBuffersFormat = 0x100 | (depth_format << 4) | color_format;
+
     Width=vm.width;
     Height=vm.height;
 
@@ -3549,7 +3602,7 @@ int pb_init(void)
     //pitch is the gap between start of a pixel line and start of next pixel line
     //(not necessarily the size of a pixel line, because of hardware optimization)
 
-    Pitch=(((vm.bpp*HSize)>>3)+0x3F)&0xFFFFFFC0; //64 units aligned
+    Pitch=(((pb_ZetaBpp*HSize)>>3)+0x3F)&0xFFFFFFC0; //64 units aligned
     pb_DepthStencilPitch=Pitch;
 
     //look for a standard listed pitch value greater or equal to theoretical one
@@ -3575,7 +3628,7 @@ int pb_init(void)
     //Huge alignment enforcement (16 Kb aligned!) for the global size
     DSSize=(DSSize+0x3FFF)&0xFFFFC000;
 
-    DSAddr=(DWORD)MmAllocateContiguousMemoryEx(FBSize,0,0x03FFB000,0x4000,0x404);
+    DSAddr=(DWORD)MmAllocateContiguousMemoryEx(DSSize,0,0x03FFB000,0x4000,0x404);
         //NumberOfBytes,LowestAcceptableAddress,HighestAcceptableAddress,Alignment OPTIONAL,ProtectionType
 
     pb_DepthStencilAddr=DSAddr;
@@ -3587,13 +3640,18 @@ int pb_init(void)
 
     pb_DSAddr=DSAddr;
 
+    DWORD tile_flags = 0x80000001;
+    if (pb_ZetaBpp == 32) {
+        tile_flags |= 0x4000000;
+    }
+
     pb_assign_tile( 1,              //int   tile_index,
             pb_DepthStencilAddr&0x03FFFFFF, //DWORD tile_addr,
             DSSize,             //DWORD tile_size,
             Pitch,              //DWORD tile_pitch,
             0,              //DWORD tile_z_start_tag,
             0,              //DWORD tile_z_offset,
-            0x84000001          //DWORD tile_flags (0x04000000 for 32 bits)
+            tile_flags          //DWORD tile_flags (0x04000000 for 32 bits)
             );
 
 

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -3617,8 +3617,8 @@ int pb_init(void)
 
     pb_DSSize=Size;
 
-    //multiply size by number of physical frame buffers in order to obtain global size
-    DSSize=Size*FrameBufferCount;
+    // We use one shared depthbuffer
+    DSSize=Size; //FIXME: WTF?!
 
     //Huge alignment enforcement (16 Kb aligned!) for the global size
     DSSize=(DSSize+0x3FFF)&0xFFFFC000;

--- a/samples/triangle/Makefile
+++ b/samples/triangle/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = triangle
+XBE_TITLE = AAtriangle
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(wildcard $(CURDIR)/*.c)
 SHADER_OBJS = ps.inl vs.inl

--- a/samples/triangle/main.c
+++ b/samples/triangle/main.c
@@ -54,6 +54,8 @@ void main(void)
 
     XVideoSetMode(640, 480, 16, REFRESH_DEFAULT);
 
+    pb_set_zeta_format(16, FALSE);
+
     if ((status = pb_init())) {
         debugPrint("pb_init Error %d\n", status);
         XSleep(2000);
@@ -72,7 +74,7 @@ void main(void)
     alloc_vertices = MmAllocateContiguousMemoryEx(sizeof(verts), 0, 0x3ffb000, 0, 0x404);
     memcpy(alloc_vertices, verts, sizeof(verts));
     num_vertices = sizeof(verts)/sizeof(verts[0]);
-    matrix_viewport(m_viewport, 0, 0, width, height, 0, 65536.0f);
+    matrix_viewport(m_viewport, 0, 0, width, height, 0, 65535.0f);
 
     /* Setup to determine frames rendered every second */
     start = now = last = XGetTickCount();

--- a/samples/triangle/main.c
+++ b/samples/triangle/main.c
@@ -52,6 +52,8 @@ void main(void)
     int       start, last, now;
     int       fps, frames, frames_total;
 
+    XVideoSetMode(640, 480, 16, REFRESH_DEFAULT);
+
     if ((status = pb_init())) {
         debugPrint("pb_init Error %d\n", status);
         XSleep(2000);


### PR DESCRIPTION
TODO:
- Cleanup
- Check if the DMA change can be made for all DMA objects
- Check why the pitch change is necessary for Zeta.. but breaks when applied to Color
- Confirm the hax don't do anything
- Create a proper API by suppling format types instead of `Bpp` numbers
- Undo change in triangle makefile