### PR TITLE
Document mesh sample artwork conversion process

### DIFF
--- a/samples/mesh/README.md
+++ b/samples/mesh/README.md
@@ -4,3 +4,56 @@ mesh
 ![screenshot](screenshot.png)
 
 Example of drawing real geometry with textures and lighting.
+
+## Generated files
+
+This sample uses generated source-code files.
+
+### verts.h
+
+Contains the vertices and indices which describe the triangles for the mesh.
+
+See verts.py for more information.
+
+In a real-world application you'd fill the `vertices` and `indices` arrays at runtime.
+Typically by loading them from a file that is suitable for your use-case.
+
+### texture.h
+
+Contains the texture description and pixel data.
+
+See texture.py for more information.
+
+In a real-world application you'd fill the pixel array at runtime.
+Typically by loading it from a file that is suitable for your use-case.
+
+## Notes
+
+### UV coordinates
+
+The Xbox GPU differentiates between swizzled, linear textures and compressed texture formats.
+
+- Linear texture formats:
+  - Data is stored line-by-line.
+  - Various pixel formats.
+  - Bad performance.
+  - Can use arbitrary width and height.
+  - Use absolute texture coordinates.
+- Swizzled texture formats:
+  - Data is swizzled (re-arranged) into pixel blocks.
+  - Various pixel formats.
+  - Good performance (cache-friendly).
+  - Must have width and height which are power-of-two.
+  - Use normalized texture coordinates.
+- Compressed texture formats:
+  - Data must be compressed as S3TC / DXT.
+  - Compression might cause artefacts.
+  - Good performance (cache-friendly).
+  - Must have width and height which are power-of-two.
+  - Use normalized texture coordinates.
+
+This sample uses a linear-texture format.
+Therefore, the UV coordinates in this sample are non-normalized.
+
+In a real-world application you'd swizzle or compress your texture.
+Accordingly, your meshes would use normalized texture-coordinates.

--- a/samples/mesh/export_art.c
+++ b/samples/mesh/export_art.c
@@ -1,0 +1,66 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+
+// We declare attributes as double to lose as little precision as possible
+typedef struct Vertex {
+  double pos[3];
+  double normal[3];
+  double texcoord[2];
+} Vertex;
+
+#include "verts.h"
+#include "texture.h"
+
+#define ARRAY_SIZE(x) sizeof(x)/sizeof(x[0])
+
+// The indices are stored as pairs; this getter splits them
+static int index16(int index) {
+  uint32_t index_pair = indices[index / 2];
+  if (index % 2) {
+    return (index_pair >> 16) & 0xFFFF;
+  }
+  return index_pair & 0xFFFF;
+}
+
+int main() {
+
+  FILE* f = fopen("verts.obj", "wb");
+  for(int i = 0; i < ARRAY_SIZE(vertices); i++) {
+    const Vertex* v = &vertices[i];
+    fprintf(f, "v %f %f %f\n", v->pos[0], v->pos[1], v->pos[2]);
+    fprintf(f, "vn %f %f %f\n", v->normal[0], v->normal[1], v->normal[2]);
+    fprintf(f, "vt %f %f\n", v->texcoord[0], v->texcoord[1]);
+  }
+  int index_count = ARRAY_SIZE(indices) * 2;
+  assert(index_count % 3 == 0);
+  for(int i = 0; i < index_count / 3; i++) {
+    int a = 1 + index16(i * 3 + 0);
+    int b = 1 + index16(i * 3 + 1);
+    int c = 1 + index16(i * 3 + 2);
+    fprintf(f, "f %d/%d/%d %d/%d/%d %d/%d/%d\n", a,a,a, b,b,b, c,c,c);
+  }
+  fclose(f);
+
+  FILE* f_rgb = fopen("texture_rgb.ppm", "wb");
+  fprintf(f_rgb, "P3 %d %d 255\n", texture_width, texture_height);
+  FILE* f_a = fopen("texture_a.pgm", "wb");
+  fprintf(f_a, "P2 %d %d 255\n", texture_width, texture_height);
+  for(int y = 0; y < texture_height; y++) {
+    for(int x = 0; x < texture_width; x++) {
+      int pixel_offset = y * texture_pitch + x * 4;
+      int r = texture_rgba[pixel_offset + 0];
+      int g = texture_rgba[pixel_offset + 1];
+      int b = texture_rgba[pixel_offset + 2];
+      int a = texture_rgba[pixel_offset + 3];
+      fprintf(f_rgb, "%d %d %d\n", r,g,b);
+      fprintf(f_a, "%d\n", a);
+    }
+    fprintf(f_rgb, "\n");
+    fprintf(f_a, "\n");
+  }
+  fclose(f_rgb);
+  fclose(f_a);
+
+  return 0;
+}

--- a/samples/mesh/main.c
+++ b/samples/mesh/main.c
@@ -84,6 +84,8 @@ void main(void)
         return;
     }
 
+Sleep(100);
+
     pb_show_front_screen();
 
     /* Basic setup */

--- a/samples/mesh/texture.py
+++ b/samples/mesh/texture.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# Requires PIL:
+#  pip3 install Pillow
+
+# To convert texture.png to texture.h, run:
+#  ./texture.py texture.png > texture.h
+
+import sys
+from PIL import Image
+
+# Load an image and convert it to RGBA
+image = Image.open(sys.argv[1])
+image = image.convert("RGBA")
+
+# Store metadata
+print("const unsigned int texture_width = %d;" % image.width)
+print("const unsigned int texture_height = %d;" % image.height)
+print("const unsigned int texture_pitch = %d;" % (image.width * 4))
+
+# Loop over all pixels and output them
+print("const uint8_t texture_rgba[] = {")
+pixels = image.load()
+for y in range(image.height):
+  for x in range(image.width):
+    r, g, b, a = pixels[x, y]
+    print("\t0x%02x, 0x%02x, 0x%02x, 0x%02x," % (r, g, b, a))
+print("};")

--- a/samples/mesh/verts.py
+++ b/samples/mesh/verts.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Requires http://www.assimp.org/ and pyassimp:
+#  pip3 install pyassimp
+
+# To convert verts.obj to verts.h, run:
+#  ./verts.py verts.obj > verts.h
+
+import sys
+import pyassimp
+
+processing = 0
+
+if False:
+  # We want to render triangles, so we remove anything else
+  processing |= pyassimp.postprocess.aiProcess_Triangulate
+  processing |= pyassimp.postprocess.aiProcess_FindDegenerates
+  #processing |= pyassimp.postprocess.aiProcess_SortByPType #FIXME: How to AI_CONFIG_PP_SBP_REMOVE in pyassimp?
+
+# We require UV and Normal for each vertex
+processing |= pyassimp.postprocess.aiProcess_GenUVCoords
+processing |= pyassimp.postprocess.aiProcess_GenNormals
+
+# We don't have a scene-graph, so pre-transform the mesh
+processing |= pyassimp.postprocess.aiProcess_PreTransformVertices
+
+# See https://sourceforge.net/p/assimp/discussion/817654/thread/026e9640/#0f55
+processing |= pyassimp.postprocess.aiProcess_JoinIdenticalVertices
+
+# Load the 3D model
+scene = pyassimp.load(sys.argv[1], processing=processing)
+
+# We need exactly 1 mesh
+assert(len(scene.meshes) == 1)
+
+# Get the mesh
+mesh = scene.meshes[0]
+
+# We need at least 1 texcoord
+#FIXME: Warn that others will be ignored
+assert(len(mesh.texturecoords) >= 1)
+if len(mesh.texturecoords) != 1:
+  print("Warning: Only first UV set is used", file=sys.stderr)
+
+# We need normals and texcoord for each vertex
+assert(len(mesh.normals) == len(mesh.vertices))
+assert(len(mesh.texturecoords[0]) == len(mesh.vertices))
+
+# Output all vertices
+print("struct Vertex vertices[] = {")
+for i, vertex in enumerate(mesh.vertices):
+  x, y, z = vertex
+  nx, ny, nz = mesh.normals[i]
+  u, v, _ = mesh.texturecoords[0][i]
+  print("\t{{ %s, %s, %s }, { %s, %s, %s }, { %s, %s }}," % (x, y, z,
+                                                             nx, ny, nz,
+                                                             u, v))
+print("};")
+print("")
+
+# Output all indices
+print("uint16_t indices[] = {")
+for face in mesh.faces:
+  assert(len(face) == 3)
+  a, b, c = face
+  assert(a <= 0xFFFF)
+  assert(b <= 0xFFFF)
+  assert(c <= 0xFFFF)
+  print("\t%d, %d, %d," % (a, b, c))
+print("};")
+
+# Unload assimp scene
+pyassimp.release(scene)


### PR DESCRIPTION
WIP stuff.

- XQEMU hack must be removed
- "Tool to export mesh sample art" should just be a comment in upstream issue
- Texture description should be moved into a new sample
- Other samples should get a similar "Notes" section
- Python-script-PR needs to be renamed and tools need testing
- An additional note about indices being 16-bit pairs, or switch to 32-bit is necessary, unless we port to XGUX (planned).