### PR TITLE
usb: Don't consume events at startup

### DIFF
--- a/lib/usb/sys/BootUSB.c
+++ b/lib/usb/sys/BootUSB.c
@@ -60,11 +60,6 @@ void BootStartUSB(void)
 	XRemoteInit();	
 	UsbKeyBoardInit();
 	UsbMouseInit();
-
-	for(n=0;n<200;n++) {
-		USBGetEvents();
-		wait_ms(1);
-	}
 }
 /*------------------------------------------------------------------------*/ 
 void USBGetEvents(void)


### PR DESCRIPTION
This was in review for upstream in PR 122, but there were issues.