### PR TITLE
fp20compiler: Support texture dependencies

### DIFF
--- a/tools/fp20compiler/ts1.0_inst_list.cpp
+++ b/tools/fp20compiler/ts1.0_inst_list.cpp
@@ -46,6 +46,7 @@ void InstList::Invoke()
            "    MASK(NV097_SET_SHADER_OTHER_STAGE_INPUT_STAGE1, 0)\n"
            "    | MASK(NV097_SET_SHADER_OTHER_STAGE_INPUT_STAGE2, 1)\n"
            "    | MASK(NV097_SET_SHADER_OTHER_STAGE_INPUT_STAGE3, 2));\n");
+    printf("p += 2;\n");
 
     printf("pb_push1(p, NV097_SET_SHADER_STAGE_PROGRAM,\n    ");
     for (i=0; i<size; i++) {

--- a/tools/fp20compiler/ts1.0_inst_list.cpp
+++ b/tools/fp20compiler/ts1.0_inst_list.cpp
@@ -42,10 +42,17 @@ void InstList::Invoke()
 {
     int i;
 
-    printf("pb_push1(p, NV097_SET_SHADER_OTHER_STAGE_INPUT,\n"
-           "    MASK(NV097_SET_SHADER_OTHER_STAGE_INPUT_STAGE1, 0)\n"
-           "    | MASK(NV097_SET_SHADER_OTHER_STAGE_INPUT_STAGE2, 1)\n"
-           "    | MASK(NV097_SET_SHADER_OTHER_STAGE_INPUT_STAGE3, 2));\n");
+    assert(size > 0);
+    printf("pb_push1(p, NV097_SET_SHADER_OTHER_STAGE_INPUT,\n    ");
+    for (i=1; i<size; i++) {
+        if (i != 1) printf("    | ");
+        int previousTexture = (int)list[i].args[0];
+        assert(i > previousTexture);
+        printf("MASK(NV097_SET_SHADER_OTHER_STAGE_INPUT_STAGE%d, %d)",
+            i, previousTexture);
+        if (i != size-1) printf("\n");
+    }
+    printf(");\n");
     printf("p += 2;\n");
 
     printf("pb_push1(p, NV097_SET_SHADER_STAGE_PROGRAM,\n    ");


### PR DESCRIPTION
**Fix bug in code emitter**

This was noticed during review of PR 187 and needs to be fixed for PR 158.

The command to set the texture stage inputs (if a texture stage depends on results of an earlier stage) was previously overwritten by the next command, as `p` was not advanced.
The de-synchronized `p` and the internal pbkit state will cause `assert(false)` to be hit in `DBG` mode after PR 158.

**Support texture dependencies**

After the fix above, it was noticed that texture dependencies wouldn't work correctly.
The old code ignored information from the shader and hardcoded mappings.
The new code does what the shader requests.

We currently don't support any texture modes which would use this feature.
However, you can still review the output using this (it will hit `assert(false)` afterwards):
```c
!!TS1.0
texture_2d(); // tex0; Can't have a dependency
texture_2d(); // tex1; Dep. 0 (always) as no other stage is valid; matching D3D
dot_product_depth_replace_1of2(tex1); // tex2; Dep. 1 in this case; matching D3D
dot_product_depth_replace_2of2(tex1); // tex3; Dep. 1 in this case; matching D3D (note: I had expected dep. 2)
// End of program
```
This shows that the dependencies are emitted correctly (expecting `0,1,1`; this is what I also saw in D3D).

There's a very slim chance that the hardware actually needs `0,1,2` (see note above). If that's the case, we'll notice it later when implementing the modes and we can fix it later.

After merge, I'll create an issue about the unsupported texture modes and remind that the texture-dependencies could still be wrong.