### PR TITLE
fp20compiler: Fix constant color encoding

### DIFF
--- a/tools/fp20compiler/rc1.0_combiners.cpp
+++ b/tools/fp20compiler/rc1.0_combiners.cpp
@@ -21,37 +21,56 @@ void CombinersStruct::Validate()
 
 void CombinersStruct::Invoke()
 {
-    // for (int i = 0; i < numConsts; i++)
-    //     glCombinerParameterfvNV(cc[i].reg.bits.name, &(cc[i].v[0]));
     assert(numConsts <= 2);
-
-    printf("pb_push1(p, NV097_SET_COMBINER_CONTROL,");
-    printf("\n    MASK(NV097_SET_COMBINER_CONTROL_FACTOR0, %s)",
-        numConsts >= 1 ? "NV097_SET_COMBINER_CONTROL_FACTOR1_SAME_FACTOR_ALL"
-            : "NV097_SET_COMBINER_CONTROL_FACTOR0_EACH_STAGE");
-    printf("\n    | MASK(NV097_SET_COMBINER_CONTROL_FACTOR1, %s)",
-        numConsts >= 2 ? "NV097_SET_COMBINER_CONTROL_FACTOR1_SAME_FACTOR_ALL"
-            : "NV097_SET_COMBINER_CONTROL_FACTOR1_EACH_STAGE");
-    printf("\n    | MASK(NV097_SET_COMBINER_CONTROL_ITERATION_COUNT, %d)", generals.num);
-    printf(");\n");
-    printf("p += 2;\n");
-
     for (int i = 0; i < numConsts; i++) {
-        const char* cmd = NULL;
-        switch (cc[i].reg.bits.name) {
+    //     glCombinerParameterfvNV(cc[i].reg.bits.name, &(cc[i].v[0]));
+        const char* general_cmd = NULL;
+        const char* final_cmd = NULL;
+        switch(cc[i].reg.bits.name) {
         case REG_CONSTANT_COLOR0:
-            cmd = "NV097_SET_SPECULAR_FOG_FACTOR + 0";
+            general_cmd = "NV097_SET_COMBINER_FACTOR0";
+            final_cmd = "NV097_SET_SPECULAR_FOG_FACTOR + 0";
             break;
         case REG_CONSTANT_COLOR1:
-            cmd = "NV_097_SET_SPECULAR_FOG_FACTOR + 4";
+            general_cmd = "NV097_SET_COMBINER_FACTOR1";
+            final_cmd = "NV097_SET_SPECULAR_FOG_FACTOR + 4";
             break;
         default:
             assert(false);
             break;
         }
-        printf("pb_push4f(p, %s, %f, %f, %f, %f);\n", cmd,
-            cc[i].v[0], cc[i].v[1], cc[i].v[2], cc[i].v[3]);
-        printf("p += 5;\n");
+
+        assert(cc[i].v[0] >= 0.0f && cc[i].v[0] <= 1.0f);
+        assert(cc[i].v[1] >= 0.0f && cc[i].v[1] <= 1.0f);
+        assert(cc[i].v[2] >= 0.0f && cc[i].v[2] <= 1.0f);
+        assert(cc[i].v[3] >= 0.0f && cc[i].v[3] <= 1.0f);
+
+        // - If no local-constants are used, the general-combiners only use
+        //   global-constants (so we use FACTOR#_SAME_FACTOR_ALL).
+        //   NV2A takes those from the first stage, which we emit here.
+        // - If any local-constants are used, we don't emit this. The locals
+        //   just overlay the globals and each stage (including the first)
+        //   will emit its own constants (for FACTOR#_EACH_STAGE).
+        // Also see mode selection in GeneralCombinersStruct::Invoke() and
+        // local-constant emitter in GeneralCombinerStruct::Invoke(int stage).
+        if (generals.localConsts == 0) {
+            printf("pb_push1(p, %s,", general_cmd);
+            printf("\n    MASK(0xFF000000, 0x%02X)", (unsigned char)(cc[i].v[3] * 0xFF));
+            printf("\n    | MASK(0x00FF0000, 0x%02X)", (unsigned char)(cc[i].v[0] * 0xFF));
+            printf("\n    | MASK(0x0000FF00, 0x%02X)", (unsigned char)(cc[i].v[1] * 0xFF));
+            printf("\n    | MASK(0x000000FF, 0x%02X)", (unsigned char)(cc[i].v[2] * 0xFF));
+            printf(");\n");
+            printf("p += 2;\n");
+        }
+
+        // Global-constants are also used in final-combiner
+        printf("pb_push1(p, %s,", final_cmd);
+        printf("\n    MASK(0xFF000000, 0x%02X)", (unsigned char)(cc[i].v[3] * 0xFF));
+        printf("\n    | MASK(0x00FF0000, 0x%02X)", (unsigned char)(cc[i].v[0] * 0xFF));
+        printf("\n    | MASK(0x0000FF00, 0x%02X)", (unsigned char)(cc[i].v[1] * 0xFF));
+        printf("\n    | MASK(0x000000FF, 0x%02X)", (unsigned char)(cc[i].v[2] * 0xFF));
+        printf(");\n");
+        printf("p += 2;\n");
     }
 
 

--- a/tools/fp20compiler/rc1.0_general.cpp
+++ b/tools/fp20compiler/rc1.0_general.cpp
@@ -60,6 +60,17 @@ void GeneralCombinersStruct::Invoke()
     //         glDisable(GL_PER_STAGE_CONSTANTS_NV);
     // }
     // assert(false);
+
+    printf("pb_push1(p, NV097_SET_COMBINER_CONTROL,");
+    printf("\n    MASK(NV097_SET_COMBINER_CONTROL_FACTOR0, %s)",
+        localConsts > 0 ? "NV097_SET_COMBINER_CONTROL_FACTOR0_EACH_STAGE"
+                : "NV097_SET_COMBINER_CONTROL_FACTOR0_SAME_FACTOR_ALL");
+    printf("\n    | MASK(NV097_SET_COMBINER_CONTROL_FACTOR1, %s)",
+        localConsts > 0 ? "NV097_SET_COMBINER_CONTROL_FACTOR1_EACH_STAGE"
+                : "NV097_SET_COMBINER_CONTROL_FACTOR1_SAME_FACTOR_ALL");
+    printf("\n    | MASK(NV097_SET_COMBINER_CONTROL_ITERATION_COUNT, %d)", num);
+    printf(");\n");
+    printf("p += 2;\n");
 }
 
 void GeneralCombinerStruct::ZeroOut()
@@ -136,9 +147,19 @@ void GeneralCombinerStruct::Invoke(int stage)
             assert(false);
             break;
         }
-        printf("pb_push4f(p, %s + %d * 4, %f, %f, %f, %f);\n", cmd, i,
-            cc[i].v[0], cc[i].v[1], cc[i].v[2], cc[i].v[3]);
-        printf("p += 5;\n");
+
+        assert(cc[i].v[0] >= 0.0f && cc[i].v[0] <= 1.0f);
+        assert(cc[i].v[1] >= 0.0f && cc[i].v[1] <= 1.0f);
+        assert(cc[i].v[2] >= 0.0f && cc[i].v[2] <= 1.0f);
+        assert(cc[i].v[3] >= 0.0f && cc[i].v[3] <= 1.0f);
+
+        printf("pb_push1(p, %s + %d * 4,", cmd, stage);
+        printf("\n    MASK(0xFF000000, 0x%02X)", (unsigned char)(cc[i].v[3] * 0xFF));
+        printf("\n    | MASK(0x00FF0000, 0x%02X)", (unsigned char)(cc[i].v[0] * 0xFF));
+        printf("\n    | MASK(0x0000FF00, 0x%02X)", (unsigned char)(cc[i].v[1] * 0xFF));
+        printf("\n    | MASK(0x000000FF, 0x%02X)", (unsigned char)(cc[i].v[2] * 0xFF));
+        printf(");\n");
+        printf("p += 2;\n");
     }
 
     for (i = 0; i < 2; i++)

--- a/tools/fp20compiler/rc1.0_general.h
+++ b/tools/fp20compiler/rc1.0_general.h
@@ -99,7 +99,6 @@ public:
     void Invoke();
     GeneralCombinerStruct general[RCP_NUM_GENERAL_COMBINERS];
     int num;
-private:
     int localConsts;
 };
 


### PR DESCRIPTION
Closes upstream issue 132.

See [this XboxDevWiki article for a description of register-combiners](http://xboxdevwiki.net/NV2A/Pixel_Combiner#Register_combiners).

The old code..
- ..erroneously chose per-stage constant-colors (`FACTOR#_EACH_STAGE` instead of `FACTOR#_SAME_FACTOR_ALL`), depending on number of constant-colors defined in global scope. Instead, this selection should depend on the number of local-colors (per-stage) instead. This needed a larger refactor, see below.
- ..emitted code had a typo for final combiner `const1` which lead to compilation errors if it was used.
- ..pushed colors in 4 floats. This is wrong and caused GPU command overflows / garbage colors.
- ..updated wrong constant in almost any case (used wrong variable in emitter-`printf`).

This PR fixes all of those issues.

The old GL code from nvparse was reused for `FACTOR#_EACH_STAGE` / `FACTOR#_SAME_FACTOR_ALL` mode selection and constant handling, but a minor changes were made for NV2A:
- As the final-combiners constant-colors are separate in NV2A, we always emit our global constant-colors for the final-combiner. This could change in the future, see issue 197.
- For `FACTOR#_SAME_FACTOR_ALL`, we also have to emit the global-constants into the first stage . See code and XboxDevWiki for details.

Some minor issues:

- When mixing globals and locals, the globals are inlined.
    There are no checks if constants are even used, so this leads to dead-code.
    This is an issue / feature of the original nvparse implementation.
    It's a minor annoyance for most use-cases (useless writes to color registers).
    We should create an issue after merge.
- We don't split `FACTOR#_SAME_FACTOR_ALL` / `FACTOR#_EACH_STAGE` for `const0` and `const1`.
    This is possible with NV2A, but not in GL, so fp20compiler has no code to handle this.
    At the moment, if any `const0` or `const1` is defined locally, both will be set to `FACTOR#_EACH_STAGE`.
    This might affect performance.
    We should create an issue after merge.

---

I have a lot of different tests in https://github.com/JayFoxRox/nxdk/pull/34.

FIXME:
- Rename PR to match commit title