### PR TITLE
Register input swizzle test

### DIFF
--- a/samples/triangle/0-ps.inl.rgba_rgba
+++ b/samples/triangle/0-ps.inl.rgba_rgba
@@ -1,0 +1,12 @@
+// C-style
+!!RC1.0
+{
+  rgb {
+    spare0 = col0.rgb; // NV097_SET_COMBINER_COLOR_ICW_A_ALPHA = 0
+  }
+  alpha {
+    spare0 = col0.a; // NV097_SET_COMBINER_ALPHA_ICW_A_ALPHA = 1
+  }
+}
+out.rgb = spare0.rgb; // NV097_SET_COMBINER_SPECULAR_FOG_CW0_A_ALPHA = 0
+out.a = spare0.a; // NV097_SET_COMBINER_SPECULAR_FOG_CW1_G_ALPHA = 1

--- a/samples/triangle/1-ps.inl.rgba_rgbb
+++ b/samples/triangle/1-ps.inl.rgba_rgbb
@@ -1,0 +1,12 @@
+// C-style
+!!RC1.0
+{
+  rgb {
+    spare0 = col0.rgb; // NV097_SET_COMBINER_COLOR_ICW_A_ALPHA = 0
+  }
+  alpha {
+    spare0 = col0.a; // NV097_SET_COMBINER_ALPHA_ICW_A_ALPHA = 1
+  }
+}
+out.rgb = spare0.rgb; // NV097_SET_COMBINER_SPECULAR_FOG_CW0_A_ALPHA = 0
+out.a = spare0.b; // NV097_SET_COMBINER_SPECULAR_FOG_CW1_G_ALPHA = 1

--- a/samples/triangle/1-ps.inl.rgbb_rgba
+++ b/samples/triangle/1-ps.inl.rgbb_rgba
@@ -1,0 +1,12 @@
+// C-style
+!!RC1.0
+{
+  rgb {
+    spare0 = col0.rgb; // NV097_SET_COMBINER_COLOR_ICW_A_ALPHA = 0
+  }
+  alpha {
+    spare0 = col0.b; // NV097_SET_COMBINER_ALPHA_ICW_A_ALPHA = 0
+  }
+}
+out.rgb = spare0.rgb; // NV097_SET_COMBINER_SPECULAR_FOG_CW0_A_ALPHA = 0
+out.a = spare0.a; // NV097_SET_COMBINER_SPECULAR_FOG_CW1_G_ALPHA = 1

--- a/samples/triangle/2-ps.inl.aaab_rgba
+++ b/samples/triangle/2-ps.inl.aaab_rgba
@@ -1,0 +1,12 @@
+// C-style
+!!RC1.0
+{
+  rgb {
+    spare0 = col0.a; // NV097_SET_COMBINER_COLOR_ICW_A_ALPHA = 1
+  }
+  alpha {
+    spare0 = col0.b; // NV097_SET_COMBINER_ALPHA_ICW_A_ALPHA = 0
+  }
+}
+out.rgb = spare0.rgb; // NV097_SET_COMBINER_SPECULAR_FOG_CW0_A_ALPHA = 0
+out.a = spare0.a; // NV097_SET_COMBINER_SPECULAR_FOG_CW1_G_ALPHA = 1

--- a/samples/triangle/2-ps.inl.rgba_aaab
+++ b/samples/triangle/2-ps.inl.rgba_aaab
@@ -1,0 +1,12 @@
+// C-style
+!!RC1.0
+{
+  rgb {
+    spare0 = col0.rgb; // NV097_SET_COMBINER_COLOR_ICW_A_ALPHA = 0
+  }
+  alpha {
+    spare0 = col0.a; // NV097_SET_COMBINER_ALPHA_ICW_A_ALPHA = 1
+  }
+}
+out.rgb = spare0.aaa; // NV097_SET_COMBINER_SPECULAR_FOG_CW0_A_ALPHA = 0
+out.a = spare0.b; // NV097_SET_COMBINER_SPECULAR_FOG_CW1_G_ALPHA = 1

--- a/samples/triangle/3-ps.inl.aaaa_rgba
+++ b/samples/triangle/3-ps.inl.aaaa_rgba
@@ -1,0 +1,12 @@
+// C-style
+!!RC1.0
+{
+  rgb {
+    spare0 = col0.a; // NV097_SET_COMBINER_COLOR_ICW_A_ALPHA = 1
+  }
+  alpha {
+    spare0 = col0.a; // NV097_SET_COMBINER_ALPHA_ICW_A_ALPHA = 1
+  }
+}
+out.rgb = spare0.rgb; // NV097_SET_COMBINER_SPECULAR_FOG_CW0_A_ALPHA = 0
+out.a = spare0.a; // NV097_SET_COMBINER_SPECULAR_FOG_CW1_G_ALPHA = 1

--- a/samples/triangle/3-ps.inl.rgba_aaaa
+++ b/samples/triangle/3-ps.inl.rgba_aaaa
@@ -1,0 +1,12 @@
+// C-style
+!!RC1.0
+{
+  rgb {
+    spare0 = col0.rgb; // NV097_SET_COMBINER_COLOR_ICW_A_ALPHA = 0
+  }
+  alpha {
+    spare0 = col0.a; // NV097_SET_COMBINER_ALPHA_ICW_A_ALPHA = 1
+  }
+}
+out.rgb = spare0.aaa; // NV097_SET_COMBINER_SPECULAR_FOG_CW0_A_ALPHA = 0
+out.a = spare0.a; // NV097_SET_COMBINER_SPECULAR_FOG_CW1_G_ALPHA = 1

--- a/samples/triangle/Makefile
+++ b/samples/triangle/Makefile
@@ -1,6 +1,10 @@
+# Compile this like this:
+# ../../tools/fp20compiler/fp20compiler 3-ps.inl.aaaa_rgba > ps.inl && make; rm -f ps.inl
+
+
 XBE_TITLE = triangle
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(wildcard $(CURDIR)/*.c)
-SHADER_OBJS = ps.inl vs.inl
+SHADER_OBJS = vs.inl
 NXDK_DIR = $(CURDIR)/../..
 include $(NXDK_DIR)/Makefile

--- a/samples/triangle/ps.ps.cg
+++ b/samples/triangle/ps.ps.cg
@@ -1,8 +1,0 @@
-struct vOut {
-	float4 color : COLOR;
-};
-
-float4 main(vOut I) : COLOR
-{
-	return I.color;
-}

--- a/tools/fp20compiler/rc1.0_general.cpp
+++ b/tools/fp20compiler/rc1.0_general.cpp
@@ -232,10 +232,16 @@ void GeneralFunctionStruct::Validate(int stage, int portion)
 }
 
 static void GenerateInput(int portion, char variable, MappedRegisterStruct reg) {
+
+    // For RGB we can select .rgb or .aaa
+    assert((portion != RCP_RGB) || ((reg.reg.bits.channel == RCP_RGB) || (reg.reg.bits.channel == RCP_ALPHA)));
+    // For ALPHA we can select .b or .a
+    assert((portion != RCP_ALPHA) || ((reg.reg.bits.channel == RCP_BLUE) || (reg.reg.bits.channel == RCP_ALPHA)));
+
     const char* portion_s = portion == RCP_RGB ? "COLOR" : "ALPHA";
     printf("MASK(NV097_SET_COMBINER_%s_ICW_%c_SOURCE, 0x%x)", portion_s, variable, reg.reg.bits.name);
-    bool alpha_channel = ((portion == RCP_RGB && reg.reg.bits.channel == RCP_BLUE) || (portion == RCP_ALPHA));
-    printf(" | MASK(NV097_SET_COMBINER_%s_ICW_%c_ALPHA, %d)", portion_s, variable, alpha_channel);
+    printf(" | MASK(NV097_SET_COMBINER_%s_ICW_%c_ALPHA, %d)", portion_s, variable,
+            reg.reg.bits.channel == RCP_ALPHA);
     printf(" | MASK(NV097_SET_COMBINER_%s_ICW_%c_MAP, 0x%x)", portion_s, variable, reg.map);
 }
 


### PR DESCRIPTION
This was used to test #27 

Based on what nvparse reports (*Note: The errors are actually suppressed, see issue 189*), we assume that RGB portion allows .rgb and .aaa; ALPHA allows .b and .a:

- RGB portion:
    ```c
    out.rgb = col0.rgb; // allowed (emitter: ALPHA flag assumed to be 0)
    out.rgb = col0.a; // allowed (emitter: ALPHA flag assumed to be 1)
    out.rgb = col0.r; // error: unrecognized token
    out.rgb = col0.b; // error: blue register used in final rgb
    ```

- ALPHA portion:
    ```c
    out.a = col0.b; // allowed (emitter: ALPHA flag assumed to be 0)
    out.a = col0.a; // allowed (emitter: ALPHA flag assumed to be 1)
    out.a = col0.r; // error: unrecognized token
    out.a = col0.rgb; // error: rgb register used in final alpha
    ```

These test shaders test the alpha flag in both sections where they can appear (general-combiner and final-combiner) in every allowed variation.

The test setup moves a color into spare0 (using general combiner).
spare0 is then moved to output (using final combiner).
This allows us to test swizzles in each of those sections.

There's a total of 7 tests:
- There's one individual test which is just a pass-through for general and final (both .rgba).
- Then there are 3 test-pairs to test swizzles (.aaaa, .aaab, .rgbb); each pair is:
    1. general is pass-through (.rgba), final does a swizzle.
    2. general does a swizzle, final is pass-through (.rgba).



Due to limitations in cgc (doesn't allow `.b`), I wrote my tests in nvparse format (which causes awkward compilation).

**Warning for people who modify this test:**

**FIXME:** Confirm this is really happening - I didn't spot such behaviour in the code.
For testing, we can't use constants (I use `col0` instead):
- constant-colors are swizzled at compile-time instead of swizzling at runtime
- Additionally, constant-colors are broken in fp20compiler at time of writing

---

I tested this on hardware and I believe it confirmed the assumptions above. The implementation for nxdk can be found in #27:

- ALPHA flag should be 0 for .rgb or .b
- ALPHA flag should be 1 for .aaa or .a
- There's no difference between general or combiner stages (in terms of ALPHA flag)
- The results make sense; it means there's probably no .bbb mode (as implied by existing code - I think I've seen this in fp20compiler and cxbx)

The test results have been documented in http://xboxdevwiki.net/NV2A/Pixel_Combiner#Encoding_of_input_swizzle

I believe there's bugs / uncertainty about this feature in XQEMU (possibly in https://github.com/JayFoxRox/xqemu/pull/16 or https://github.com/JayFoxRox/xqemu/pull/21) and nv2a-trace. So this sample can serve as reference for the future.