### PR TITLE
Blue to Alpha test

### DIFF
--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -2384,6 +2384,23 @@ void pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD p
     *(p+4)=param4;
 }
 
+void pb_push4fto(DWORD subchannel, DWORD *p, DWORD command, float param1, float param2, float param3, float param4)
+{
+#ifdef DBG
+    if (p!=pb_PushNext) debugPrint("pb_push4fto : new write address invalid or not following previous write addresses\n");
+    if (pb_BeginEndPair==0) debugPrint("pb_push4fto : missing pb_begin earlier\n");
+    pb_PushIndex+=5;
+    pb_PushNext+=5;
+    if (pb_PushIndex>128) debugPrint("pb_push4fto: begin-end block musn't exceed 128 dwords\n");
+#endif
+
+    *(p+0)=EncodeMethod(subchannel,command,4);
+    *((float *)(p+1))=param1;
+    *((float *)(p+2))=param2;
+    *((float *)(p+3))=param3;
+    *((float *)(p+4))=param4;
+}
+
 void pb_push(DWORD *p, DWORD command, DWORD nparam)
 {
     pb_pushto(SUBCH_3D,p,command,nparam);

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -1894,7 +1894,7 @@ void pb_target_back_buffer(void)
     pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
     pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x04,dma_limit); p+=3;
     pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push1to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT2,11); p+=2;
+    pb_push1_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT2,11); p+=2;
     pb_end(p);
 
     depth_stencil=1;
@@ -2014,7 +2014,7 @@ void pb_target_extra_buffer(int index_buffer)
     pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
     pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x04,dma_limit); p+=3;
     pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push1to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT2,11); p+=2;
+    pb_push1_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT2,11); p+=2;
     pb_end(p);
     
     depth_stencil=1;
@@ -2306,7 +2306,7 @@ void pb_end(DWORD *pEnd)
 }
 
 
-inline DWORD *pb_pushto(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam)
+inline DWORD *pb_push_to(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam)
 {
 #ifdef DBG
     if (p!=pb_PushNext)
@@ -2332,33 +2332,33 @@ inline DWORD *pb_pushto(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam)
     return p+1+nparam;
 }
 
-inline DWORD *pb_push1to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1)
+inline DWORD *pb_push1_to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1)
 {
-    pb_pushto(subchannel,p,command,1);
+    pb_push_to(subchannel,p,command,1);
     *(p+1)=param1;
     return p+2;
 }
 
-inline DWORD *pb_push2to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2)
+inline DWORD *pb_push2_to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2)
 {
-    pb_pushto(subchannel,p,command,2);
+    pb_push_to(subchannel,p,command,2);
     *(p+1)=param1;
     *(p+2)=param2;
     return p+3;
 }
 
-inline DWORD *pb_push3to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3)
+inline DWORD *pb_push3_to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3)
 {
-    pb_pushto(subchannel,p,command,3);
+    pb_push_to(subchannel,p,command,3);
     *(p+1)=param1;
     *(p+2)=param2;
     *(p+3)=param3;
     return p+4;
 }
 
-inline DWORD *pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4)
+inline DWORD *pb_push4_to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4)
 {
-    pb_pushto(subchannel,p,command,4);
+    pb_push_to(subchannel,p,command,4);
     *(p+1)=param1;
     *(p+2)=param2;
     *(p+3)=param3;
@@ -2366,9 +2366,9 @@ inline DWORD *pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1
     return p+5;
 }
 
-inline DWORD *pb_push4fto(DWORD subchannel, DWORD *p, DWORD command, float param1, float param2, float param3, float param4)
+inline DWORD *pb_push4f_to(DWORD subchannel, DWORD *p, DWORD command, float param1, float param2, float param3, float param4)
 {
-    pb_pushto(subchannel,p,command,4);
+    pb_push_to(subchannel,p,command,4);
     *((float *)(p+1))=param1;
     *((float *)(p+2))=param2;
     *((float *)(p+3))=param3;
@@ -2378,37 +2378,37 @@ inline DWORD *pb_push4fto(DWORD subchannel, DWORD *p, DWORD command, float param
 
 inline DWORD *pb_push(DWORD *p, DWORD command, DWORD nparam)
 {
-    return pb_pushto(SUBCH_3D,p,command,nparam);
+    return pb_push_to(SUBCH_3D,p,command,nparam);
 }
 
 inline DWORD *pb_push1(DWORD *p, DWORD command, DWORD param1)
 {
-    return pb_push1to(SUBCH_3D,p,command,param1);
+    return pb_push1_to(SUBCH_3D,p,command,param1);
 }
 
 inline DWORD *pb_push2(DWORD *p, DWORD command, DWORD param1, DWORD param2)
 {
-    return pb_push2to(SUBCH_3D,p,command,param1,param2);
+    return pb_push2_to(SUBCH_3D,p,command,param1,param2);
 }
 
 inline DWORD *pb_push3(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3)
 {
-    return pb_push3to(SUBCH_3D,p,command,param1,param2,param3);
+    return pb_push3_to(SUBCH_3D,p,command,param1,param2,param3);
 }
 
 inline DWORD *pb_push4(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4)
 {
-    return pb_push4to(SUBCH_3D,p,command,param1,param2,param3,param4);
+    return pb_push4_to(SUBCH_3D,p,command,param1,param2,param3,param4);
 }
 
 inline DWORD *pb_push4f(DWORD *p, DWORD command, float param1, float param2, float param3, float param4)
 {
-    return pb_push4fto(SUBCH_3D,p,command,param1,param2,param3,param4);
+    return pb_push4f_to(SUBCH_3D,p,command,param1,param2,param3,param4);
 }
 
 inline DWORD *pb_push_transposed_matrix(DWORD *p, DWORD command, float *m)
 {
-    pb_pushto(SUBCH_3D,p++,command,16);
+    pb_push_to(SUBCH_3D,p++,command,16);
 
     *((float *)p++)=m[_11];
     *((float *)p++)=m[_21];
@@ -3364,14 +3364,14 @@ int pb_init(void)
     //These commands assign DMA channels to push buffer subchannels
     //and associate some specific GPU parts to specific Dma channels
     p=pb_begin();
-    pb_push1to(SUBCH_2,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,14); p+=2;
-    pb_push1to(SUBCH_3,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,16); p+=2;
-    pb_push1to(SUBCH_4,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,17); p+=2;
-    pb_push1to(SUBCH_3D,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,13); p+=2;
-    pb_push1to(SUBCH_2,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT0,7); p+=2;
-    pb_push1to(SUBCH_3,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT5,17); p+=2;
-    pb_push1to(SUBCH_3,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT_UNKNOWN,3); p+=2;
-    pb_push2to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT1,3,11); p+=3;
+    pb_push1_to(SUBCH_2,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,14); p+=2;
+    pb_push1_to(SUBCH_3,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,16); p+=2;
+    pb_push1_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,17); p+=2;
+    pb_push1_to(SUBCH_3D,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,13); p+=2;
+    pb_push1_to(SUBCH_2,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT0,7); p+=2;
+    pb_push1_to(SUBCH_3,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT5,17); p+=2;
+    pb_push1_to(SUBCH_3,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT_UNKNOWN,3); p+=2;
+    pb_push2_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT1,3,11); p+=3;
     pb_end(p); //calls pb_start() which will trigger the reading and sending to GPU (asynchronous, no waiting)
 
     //setup needed for color computations

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -2267,7 +2267,16 @@ void pb_end(DWORD *pEnd)
 #endif
 
 #ifdef DBG
-    if (pb_BeginEndPair==0) debugPrint("pb_end without a pb_start\n");
+    if (pEnd!=pb_PushNext)
+    {
+        debugPrint("pb_end: input pointer invalid or not following previous write addresses\n");
+        assert(false);
+    }
+    if (pb_BeginEndPair==0)
+    {
+        debugPrint("pb_end without a pb_start\n");
+        assert(false);
+    }
     pb_BeginEndPair=0;
 #endif
 

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -2297,7 +2297,7 @@ void pb_end(DWORD *pEnd)
 }
 
 
-void pb_pushto(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam)
+inline DWORD *pb_pushto(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam)
 {
 #ifdef DBG
     if (p!=pb_PushNext)
@@ -2320,182 +2320,86 @@ void pb_pushto(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam)
 #endif
 
     *(p+0)=EncodeMethod(subchannel,command,nparam);
+    return p+1+nparam;
 }
 
-void pb_push1to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1)
+inline DWORD *pb_push1to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push1to: new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push1to: missing pb_begin earlier\n");
-    pb_PushIndex+=2;
-    pb_PushNext+=2;
-    if (pb_PushIndex>128) debugPrint("pb_push1to: begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p+0)=EncodeMethod(subchannel,command,1);
+    pb_pushto(subchannel,p,command,1);
     *(p+1)=param1;
+    return p+2;
 }
 
-void pb_push2to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2)
+inline DWORD *pb_push2to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push2to : new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push2to : missing pb_begin earlier\n");
-    pb_PushIndex+=3;
-    pb_PushNext+=3;
-    if (pb_PushIndex>128) debugPrint("pb_push2to: begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p+0)=EncodeMethod(subchannel,command,2);
+    pb_pushto(subchannel,p,command,2);
     *(p+1)=param1;
     *(p+2)=param2;
+    return p+3;
 }
 
-void pb_push3to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3)
+inline DWORD *pb_push3to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push3to : new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push3to : missing pb_begin earlier\n");
-    pb_PushIndex+=4;
-    pb_PushNext+=4;
-    if (pb_PushIndex>128) debugPrint("pb_push3to: begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p+0)=EncodeMethod(subchannel,command,3);
+    pb_pushto(subchannel,p,command,3);
     *(p+1)=param1;
     *(p+2)=param2;
     *(p+3)=param3;
+    return p+4;
 }
 
-void pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4)
+inline DWORD *pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push4to : new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push4to : missing pb_begin earlier\n");
-    pb_PushIndex+=5;
-    pb_PushNext+=5;
-    if (pb_PushIndex>128) debugPrint("pb_push4to: begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p+0)=EncodeMethod(subchannel,command,4);
+    pb_pushto(subchannel,p,command,4);
     *(p+1)=param1;
     *(p+2)=param2;
     *(p+3)=param3;
     *(p+4)=param4;
+    return p+5;
 }
 
-void pb_push4fto(DWORD subchannel, DWORD *p, DWORD command, float param1, float param2, float param3, float param4)
+inline DWORD *pb_push4fto(DWORD subchannel, DWORD *p, DWORD command, float param1, float param2, float param3, float param4)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push4fto : new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push4fto : missing pb_begin earlier\n");
-    pb_PushIndex+=5;
-    pb_PushNext+=5;
-    if (pb_PushIndex>128) debugPrint("pb_push4fto: begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p+0)=EncodeMethod(subchannel,command,4);
+    pb_pushto(subchannel,p,command,4);
     *((float *)(p+1))=param1;
     *((float *)(p+2))=param2;
     *((float *)(p+3))=param3;
     *((float *)(p+4))=param4;
+    return p+5;
 }
 
-void pb_push(DWORD *p, DWORD command, DWORD nparam)
+inline DWORD *pb_push(DWORD *p, DWORD command, DWORD nparam)
 {
-    pb_pushto(SUBCH_3D,p,command,nparam);
+    return pb_pushto(SUBCH_3D,p,command,nparam);
 }
 
-void pb_push1(DWORD *p, DWORD command, DWORD param1)
+inline DWORD *pb_push1(DWORD *p, DWORD command, DWORD param1)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push1: new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push1: missing pb_begin earlier\n");
-    pb_PushIndex+=2;
-    pb_PushNext+=2;
-    if (pb_PushIndex>128) debugPrint("pb_push1: begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p+0)=EncodeMethod(SUBCH_3D,command,1);
-    *(p+1)=param1;
+    return pb_push1to(SUBCH_3D,p,command,param1);
 }
 
-void pb_push2(DWORD *p, DWORD command, DWORD param1, DWORD param2)
+inline DWORD *pb_push2(DWORD *p, DWORD command, DWORD param1, DWORD param2)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push2 : new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push2 : missing pb_begin earlier\n");
-    pb_PushIndex+=3;
-    pb_PushNext+=3;
-    if (pb_PushIndex>128) debugPrint("pb_push2: begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p+0)=EncodeMethod(SUBCH_3D,command,2);
-    *(p+1)=param1;
-    *(p+2)=param2;
+    return pb_push2to(SUBCH_3D,p,command,param1,param2);
 }
 
-void pb_push3(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3)
+inline DWORD *pb_push3(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push3 : new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push3 : missing pb_begin earlier\n");
-    pb_PushIndex+=4;
-    pb_PushNext+=4;
-    if (pb_PushIndex>128) debugPrint("pb_push3: begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p+0)=EncodeMethod(SUBCH_3D,command,3);
-    *(p+1)=param1;
-    *(p+2)=param2;
-    *(p+3)=param3;
+    return pb_push3to(SUBCH_3D,p,command,param1,param2,param3);
 }
 
-void pb_push4(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4)
+inline DWORD *pb_push4(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push4 : new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push4 : missing pb_begin earlier\n");
-    pb_PushIndex+=5;
-    pb_PushNext+=5;
-    if (pb_PushIndex>128) debugPrint("pb_push4: begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p+0)=EncodeMethod(SUBCH_3D,command,4);
-    *(p+1)=param1;
-    *(p+2)=param2;
-    *(p+3)=param3;
-    *(p+4)=param4;
+    return pb_push4to(SUBCH_3D,p,command,param1,param2,param3,param4);
 }
 
-void pb_push4f(DWORD *p, DWORD command, float param1, float param2, float param3, float param4)
+inline DWORD *pb_push4f(DWORD *p, DWORD command, float param1, float param2, float param3, float param4)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push4f : new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push4f : missing pb_begin earlier\n");
-    pb_PushIndex+=5;
-    pb_PushNext+=5;
-    if (pb_PushIndex>128) debugPrint("pb_push4f: begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p+0)=EncodeMethod(SUBCH_3D,command,4);
-    *((float *)(p+1))=param1;
-    *((float *)(p+2))=param2;
-    *((float *)(p+3))=param3;
-    *((float *)(p+4))=param4;
+    return pb_push4fto(SUBCH_3D,p,command,param1,param2,param3,param4);
 }
 
-void pb_push_transposed_matrix(DWORD *p, DWORD command, float *m)
+inline DWORD *pb_push_transposed_matrix(DWORD *p, DWORD command, float *m)
 {
-#ifdef DBG
-    if (p!=pb_PushNext) debugPrint("pb_push_transposed_matrix : new write address invalid or not following previous write addresses\n");
-    if (pb_BeginEndPair==0) debugPrint("pb_push_transposed_matrix : missing pb_begin earlier\n");
-    pb_PushIndex+=17;
-    pb_PushNext+=17;
-    if (pb_PushIndex>128) debugPrint("pb_push_transposed_matrix : begin-end block musn't exceed 128 dwords\n");
-#endif
-
-    *(p++)=EncodeMethod(SUBCH_3D,command,16);
+    pb_pushto(SUBCH_3D,p++,command,16);
 
     *((float *)p++)=m[_11];
     *((float *)p++)=m[_21];
@@ -2516,9 +2420,9 @@ void pb_push_transposed_matrix(DWORD *p, DWORD command, float *m)
     *((float *)p++)=m[_24];
     *((float *)p++)=m[_34];
     *((float *)p++)=m[_44];
+
+    return p;
 }
-
-
 
 
 

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -1866,16 +1866,16 @@ void pb_target_back_buffer(void)
     dma_addr|=3;
 
     p=pb_begin();
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x08,dma_addr); p+=3; //set params addr,data
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2; //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x0C,dma_addr); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x00,dma_flags); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x04,dma_limit); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT3,9); p+=2;
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x08,dma_addr); //set params addr,data
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x0C,dma_addr);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x00,dma_flags);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x04,dma_limit);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT3,9);
     pb_end(p);
 
     //DMA channel 11 is used by GPU in order to bitblt images
@@ -1885,16 +1885,16 @@ void pb_target_back_buffer(void)
     dma_addr|=3;
     
     p=pb_begin();
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x08,dma_addr); p+=3; //set params addr,data
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2; //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x0C,dma_addr); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x00,dma_flags); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x04,dma_limit); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push1_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT2,11); p+=2;
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x08,dma_addr); //set params addr,data
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x0C,dma_addr);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x00,dma_flags);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x04,dma_limit);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push1_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT2,11);
     pb_end(p);
 
     depth_stencil=1;
@@ -1922,32 +1922,32 @@ void pb_target_back_buffer(void)
         }
         
         p=pb_begin();
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); p+=2;
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x08,dma_addr); p+=3; //set params addr,data
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2; //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x0C,dma_addr); p+=3;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x00,dma_flags); p+=3;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x04,dma_limit); p+=3;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT4,10); p+=2;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_TEST_ENABLE,flag); p+=2; //ZEnable=TRUE or FALSE (But don't use W, see below)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_ENABLE,1); p+=2;   //StencilEnable=TRUE
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0);
+        p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x08,dma_addr); //set params addr,data
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
+        p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x0C,dma_addr);
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+        p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x00,dma_flags);
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+        p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x04,dma_limit);
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT4,10);
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_TEST_ENABLE,flag); //ZEnable=TRUE or FALSE (But don't use W, see below)
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_ENABLE,1);   //StencilEnable=TRUE
         pb_end(p);
 
         pb_DepthStencilLast=depth_stencil;
     }
 
     p=pb_begin();
-    pb_push3(p,NV20_TCL_PRIMITIVE_3D_BUFFER_PITCH,(pitch_depth_stencil<<16)|(pitch&0xFFFF),0,0); p+=4;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_HORIZ,width<<16,height<<16); p+=3;
+    p=pb_push3(p,NV20_TCL_PRIMITIVE_3D_BUFFER_PITCH,(pitch_depth_stencil<<16)|(pitch&0xFFFF),0,0);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_HORIZ,width<<16,height<<16);
     //Default (0x00100001)
     //We use W (0x00010000)
     //We don't enable YUV (0x10000000)
     //We don't use floating point depth (0x00001000)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_W_YUV_FPZ_FLAGS,0x00110001); p+=2;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_BUFFER_FORMAT,pb_GPUFrameBuffersFormat|pb_FBVFlag); p+=2;
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_W_YUV_FPZ_FLAGS,0x00110001);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_BUFFER_FORMAT,pb_GPUFrameBuffersFormat|pb_FBVFlag);
     pb_end(p);
 }
 
@@ -1986,16 +1986,16 @@ void pb_target_extra_buffer(int index_buffer)
     dma_addr|=3;
 
     p=pb_begin();
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x08,dma_addr); p+=3; //set params addr,data
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2; //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x0C,dma_addr); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x00,dma_flags); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x04,dma_limit); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT3,9); p+=2;
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x08,dma_addr); //set params addr,data
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x0C,dma_addr);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x00,dma_flags);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID9Inst<<4)+0x04,dma_limit);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT3,9);
     pb_end(p);
 
     //DMA channel 11 is used by GPU in order to bitblt images
@@ -2005,16 +2005,16 @@ void pb_target_extra_buffer(int index_buffer)
     dma_addr|=3;
 
     p=pb_begin();
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x08,dma_addr); p+=3; //set params addr,data
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2; //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x0C,dma_addr); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x00,dma_flags); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x04,dma_limit); p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-    pb_push1_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT2,11); p+=2;
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x08,dma_addr); //set params addr,data
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x0C,dma_addr);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x00,dma_flags);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x04,dma_limit);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+    p=pb_push1_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT2,11);
     pb_end(p);
     
     depth_stencil=1;
@@ -2042,32 +2042,32 @@ void pb_target_extra_buffer(int index_buffer)
         }
         
         p=pb_begin();
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); p+=2;
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x08,dma_addr); p+=3; //set params addr,data
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2; //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x0C,dma_addr); p+=3;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x00,dma_flags); p+=3;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x04,dma_limit); p+=3;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT4,10); p+=2;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_TEST_ENABLE,flag); p+=2; //ZEnable=TRUE or FALSE (But don't use W, see below)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_ENABLE,1); p+=2;   //StencilEnable=TRUE
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0);
+        p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x08,dma_addr); //set params addr,data
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); //calls subprogID PB_SETOUTER: does VIDEOREG(addr)=data
+        p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x0C,dma_addr);
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+        p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x00,dma_flags);
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+        p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID10Inst<<4)+0x04,dma_limit);
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER);
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT4,10);
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_TEST_ENABLE,flag); //ZEnable=TRUE or FALSE (But don't use W, see below)
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_ENABLE,1);   //StencilEnable=TRUE
         pb_end(p);
 
         pb_DepthStencilLast=depth_stencil;
     }
 
     p=pb_begin();
-    pb_push3(p,NV20_TCL_PRIMITIVE_3D_BUFFER_PITCH,(pitch_depth_stencil<<16)|(pitch&0xFFFF),0,0); p+=4;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_HORIZ,width<<16,height<<16); p+=3;
+    p=pb_push3(p,NV20_TCL_PRIMITIVE_3D_BUFFER_PITCH,(pitch_depth_stencil<<16)|(pitch&0xFFFF),0,0);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_HORIZ,width<<16,height<<16);
     //Default (0x00100001)
     //We use W (0x00010000)
     //We don't enable YUV (0x10000000)
     //We don't use floating point depth (0x00001000)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_W_YUV_FPZ_FLAGS,0x00110001); p+=2;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_BUFFER_FORMAT,pb_GPUFrameBuffersFormat|pb_FBVFlag); p+=2;
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_W_YUV_FPZ_FLAGS,0x00110001);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_BUFFER_FORMAT,pb_GPUFrameBuffersFormat|pb_FBVFlag);
     pb_end(p);
 }
 
@@ -2486,14 +2486,14 @@ void pb_set_viewport(int dwx,int dwy,int width,int height,float zmin,float zmax)
     *((float *)&dwzmaxscaled)=zmax*pb_ZScale;
 /*
     p=pb_begin();
-    pb_push4f(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_OX,x+0.53125f,y+0.53125f,0.0f,0.0f); p+=5;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_DEPTH_RANGE_NEAR,dwzminscaled,dwzmaxscaled); p+=3;
+    p=pb_push4f(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_OX,x+0.53125f,y+0.53125f,0.0f,0.0f);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_DEPTH_RANGE_NEAR,dwzminscaled,dwzmaxscaled);
     pb_end(p);
 */
     p=pb_begin();
-    pb_push4f(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_OX,x+w,y-h,zmin*pb_ZScale,0.0f); p+=5;
-    pb_push4f(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_PX_DIV2,w,h,(zmax-zmin)*pb_ZScale,0.0f); p+=5;
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_DEPTH_RANGE_NEAR,dwzminscaled,dwzmaxscaled); p+=3;
+    p=pb_push4f(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_OX,x+w,y-h,zmin*pb_ZScale,0.0f);
+    p=pb_push4f(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_PX_DIV2,w,h,(zmax-zmin)*pb_ZScale,0.0f);
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_DEPTH_RANGE_NEAR,dwzminscaled,dwzmaxscaled);
     pb_end(p);
 }
 
@@ -2580,12 +2580,12 @@ int pb_finished(void)
 
     //insert in push buffer the commands to trigger screen swapping at next VBlank
     p=pb_begin();
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_ASK_FOR_IDLE,0); p+=2; //ask for idle
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_NOP,0); p+=2; //wait for idle
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); p+=2; //wait/makespace (obtains null status)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,pb_back_index); p+=2; //set param=back buffer index to show up
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_FINISHED); p+=2; //subprogID PB_FINISHED: gets frame ready to show up soon
-//  pb_push1(p,NV20_TCL_PRIMITIVE_3D_STALL_PIPELINE,0); p+=2; //stall gpu pipeline (not sure it's needed in triple buffering technic)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_ASK_FOR_IDLE,0); //ask for idle
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_NOP,0); //wait for idle
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); //wait/makespace (obtains null status)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,pb_back_index); //set param=back buffer index to show up
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_FINISHED); //subprogID PB_FINISHED: gets frame ready to show up soon
+//  p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STALL_PIPELINE,0); //stall gpu pipeline (not sure it's needed in triple buffering technic)
     pb_end(p);
 
     //insert in push buffer the commands to trigger selection of next back buffer
@@ -3364,14 +3364,14 @@ int pb_init(void)
     //These commands assign DMA channels to push buffer subchannels
     //and associate some specific GPU parts to specific Dma channels
     p=pb_begin();
-    pb_push1_to(SUBCH_2,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,14); p+=2;
-    pb_push1_to(SUBCH_3,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,16); p+=2;
-    pb_push1_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,17); p+=2;
-    pb_push1_to(SUBCH_3D,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,13); p+=2;
-    pb_push1_to(SUBCH_2,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT0,7); p+=2;
-    pb_push1_to(SUBCH_3,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT5,17); p+=2;
-    pb_push1_to(SUBCH_3,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT_UNKNOWN,3); p+=2;
-    pb_push2_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT1,3,11); p+=3;
+    p=pb_push1_to(SUBCH_2,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,14);
+    p=pb_push1_to(SUBCH_3,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,16);
+    p=pb_push1_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,17);
+    p=pb_push1_to(SUBCH_3D,p,NV20_TCL_PRIMITIVE_SET_MAIN_OBJECT,13);
+    p=pb_push1_to(SUBCH_2,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT0,7);
+    p=pb_push1_to(SUBCH_3,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT5,17);
+    p=pb_push1_to(SUBCH_3,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT_UNKNOWN,3);
+    p=pb_push2_to(SUBCH_4,p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT1,3,11);
     pb_end(p); //calls pb_start() which will trigger the reading and sending to GPU (asynchronous, no waiting)
 
     //setup needed for color computations
@@ -3387,33 +3387,31 @@ int pb_init(void)
     *(p++)=3;
     *(p++)=3;
     *(p++)=8;
-    pb_push(p++,NV20_TCL_PRIMITIVE_3D_SET_OBJECT8,1);
-    *(p++)=12;
-    pb_push(p++,NV20_TCL_PRIMITIVE_3D_ACTIVATE_COLORS,1);
-    *(p++)=0;
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_SET_OBJECT8,12);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_ACTIVATE_COLORS,0);
     pb_end(p);
 
     p=pb_begin();
-    pb_push1(p,NV097_SET_FLAT_SHADE_OP,1); p+=2; //FIRST_VTX 
-    pb_push4f(p,NV097_SET_EYE_POSITION,0.0f,0.0f,0.0f,1.0f); p+=5;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_EDGE_FLAG,1); p+=2;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_SHADER_PREVIOUS,0x00210000); p+=2; //(PSTextureInput) What previous stage is used at each stage
-    pb_push1(p,NV097_SET_COMPRESS_ZBUFFER_EN,0); p+=2; //
-    pb_push1(p,NV097_SET_SHADOW_ZSLOPE_THRESHOLD,0x7F800000); p+=2;
-    pb_push1(p,NV097_SET_ZMIN_MAX_CONTROL,1); p+=2; //CULL_NEAR_FAR_EN_TRUE | ZCLAMP_EN_CULL | CULL_IGNORE_W_FALSE
+    p=pb_push1(p,NV097_SET_FLAT_SHADE_OP,1); //FIRST_VTX 
+    p=pb_push4f(p,NV097_SET_EYE_POSITION,0.0f,0.0f,0.0f,1.0f);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_EDGE_FLAG,1);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_SHADER_PREVIOUS,0x00210000); //(PSTextureInput) What previous stage is used at each stage
+    p=pb_push1(p,NV097_SET_COMPRESS_ZBUFFER_EN,0); //
+    p=pb_push1(p,NV097_SET_SHADOW_ZSLOPE_THRESHOLD,0x7F800000);
+    p=pb_push1(p,NV097_SET_ZMIN_MAX_CONTROL,1); //CULL_NEAR_FAR_EN_TRUE | ZCLAMP_EN_CULL | CULL_IGNORE_W_FALSE
     pb_end(p);
 
     p=pb_begin();
-    pb_push_transposed_matrix(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_A(0),pb_IdentityMatrix); p+=17;
-    pb_push_transposed_matrix(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_A(4),pb_IdentityMatrix); p+=17;
-    pb_push_transposed_matrix(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_A(8),pb_IdentityMatrix); p+=17;
-    pb_push_transposed_matrix(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_A(12),pb_IdentityMatrix); p+=17;
-/*  pb_push1(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_ENABLE(0),0x2202);  p+=2;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_ENABLE(1),0x2202);  p+=2;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_ENABLE(2),0x2202);  p+=2;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_ENABLE(3),0x2202);  p+=2;
-*/  pb_push4f(p,NV097_SET_FOG_PLANE,0.0f,0.0f,1.0f,0.0f); p+=5;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_VP_UPLOAD_CONST_ID,0x0000003C); p+=2; //set shader constants cursor at C-36
+    p=pb_push_transposed_matrix(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_A(0),pb_IdentityMatrix);
+    p=pb_push_transposed_matrix(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_A(4),pb_IdentityMatrix);
+    p=pb_push_transposed_matrix(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_A(8),pb_IdentityMatrix);
+    p=pb_push_transposed_matrix(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_A(12),pb_IdentityMatrix);
+/*  p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_ENABLE(0),0x2202); 
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_ENABLE(1),0x2202); 
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_ENABLE(2),0x2202); 
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_CLIP_PLANE_ENABLE(3),0x2202); 
+*/  p=pb_push4f(p,NV097_SET_FOG_PLANE,0.0f,0.0f,1.0f,0.0f);
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_VP_UPLOAD_CONST_ID,0x0000003C); //set shader constants cursor at C-36
     pb_push(p++,NV20_TCL_PRIMITIVE_3D_VP_UPLOAD_CONST_X,12);        //loads C-36, C-35 & C-34
     memcpy(p,pb_FixedPipelineConstants,12*4); p+=12; //used by common xbox shaders, but I doubt we will use them.
     //(also usually C-37 is screen center offset Decals vector & c-38 is Scales vector)
@@ -3699,7 +3697,7 @@ int pb_init(void)
 
     p=pb_begin();
     n=pb_FrameBuffersCount; //(BackBufferCount+1)
-    pb_push3(p,NV20_TCL_PRIMITIVE_3D_MAIN_TILES_INDICES,0,1,n); p+=4;
+    p=pb_push3(p,NV20_TCL_PRIMITIVE_3D_MAIN_TILES_INDICES,0,1,n);
     pb_end(p);
 
     //set area where GPU is allowed to draw pixels
@@ -3707,16 +3705,16 @@ int pb_init(void)
 
     //set vertex shader type
     p=pb_begin();
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_SHADER_TYPE,SHADER_TYPE_INTERNAL); p+=2;
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_SHADER_TYPE,SHADER_TYPE_INTERNAL);
     pb_end(p);
 
     //no scissors (accept pixels in 8 rectangles covering all screen)
     p=pb_begin();
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_CLIP_MODE,0); p+=2;   //accept pixels inside scissor rectangles union (1=reject)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_CLIP_MODE,0);   //accept pixels inside scissor rectangles union (1=reject)
     for(i=0;i<8;i++)
     {
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_CLIP_HORIZ(i),0|((vm.width*HScale-1)<<16)); p+=2;
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_CLIP_VERT(i),0|((vm.height*VScale-1)<<16)); p+=2;
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_CLIP_HORIZ(i),0|((vm.width*HScale-1)<<16));
+        p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_VIEWPORT_CLIP_VERT(i),0|((vm.height*VScale-1)<<16));
     }
     pb_end(p);
 
@@ -3725,96 +3723,95 @@ int pb_init(void)
 
     //various intial settings (simple states)
     p=pb_begin();
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_FUNC,0x203); p+=2; //Depth comparison function="less or equal"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_ALPHA_FUNC_FUNC,0x207); p+=2; //Alpha comparison function="always"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_BLEND_FUNC_ENABLE,0); p+=2; //AlphaBlendEnable=FALSE
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_ALPHA_FUNC_ENABLE,0); p+=2; //AlphaTestEnable=FALSE
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_ALPHA_FUNC_REF,0); p+=2; //AlphaRef=0 
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_BLEND_FUNC_SRC,1); p+=2; //SrcBlend=(1,1,1,1)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_BLEND_FUNC_DST,0); p+=2; //DstBlend=(0,0,0,0) 
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_WRITE_ENABLE,1); p+=2; //ZWriteEnable=TRUE
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_DITHER_ENABLE,0); p+=2; //DitherEnable=FALSE
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_SHADE_MODEL,0x1D01); p+=2; //ShadeMode="gouraud"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_COLOR_MASK,0x01010101); p+=2; // ColorWriteEnable=abgr
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_OP_ZFAIL,0x1E00); p+=2; //StencilZFail="keep"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_OP_ZPASS,0x1E00); p+=2; //StencilPass="keep"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_FUNC_FUNC,0x207); p+=2; // Stencil comparison function="always"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_FUNC_REF,0); p+=2; //StencilRef=0
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_FUNC_MASK,0xFFFFFFFF); p+=2; //StencilMask=0xFFFFFFFF
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_MASK,0xFFFFFFFF); p+=2; //StencilWriteMask=0xFFFFFFFF
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_BLEND_EQUATION,0x8006); p+=2; //Blend operator="add"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_BLEND_COLOR,0); p+=2; //BlendColor=0x000000 
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_SWATHWIDTH,4); p+=2; //SwathWidth=128 
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_POLYGON_OFFSET_FACTOR,0); p+=2; //PolygonOffZSlopeScale=0.0f (because ZBias=0.0f)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_POLYGON_OFFSET_UNITS,0); p+=2; //PolygonOffZOffset=0.0f (because ZBias=0.0f)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_POLYGON_OFFSET_POINT_ENABLE,0); p+=2; //PtOffEnable=FALSE (because ZBias=0.0f)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_POLYGON_OFFSET_LINE_ENABLE,0); p+=2; //WireFrameOffEnable=FALSE (because ZBias=0.0f)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_POLYGON_OFFSET_FILL_ENABLE,0); p+=2; //SolidOffEnable=FALSE (because ZBias=0.0f)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_FUNC,0x203); //Depth comparison function="less or equal"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_ALPHA_FUNC_FUNC,0x207); //Alpha comparison function="always"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_BLEND_FUNC_ENABLE,0); //AlphaBlendEnable=FALSE
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_ALPHA_FUNC_ENABLE,0); //AlphaTestEnable=FALSE
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_ALPHA_FUNC_REF,0); //AlphaRef=0
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_BLEND_FUNC_SRC,1); //SrcBlend=(1,1,1,1)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_BLEND_FUNC_DST,0); //DstBlend=(0,0,0,0)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_DEPTH_WRITE_ENABLE,1); //ZWriteEnable=TRUE
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_DITHER_ENABLE,0); //DitherEnable=FALSE
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_SHADE_MODEL,0x1D01); //ShadeMode="gouraud"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_COLOR_MASK,0x01010101); // ColorWriteEnable=abgr
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_OP_ZFAIL,0x1E00); //StencilZFail="keep"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_OP_ZPASS,0x1E00); //StencilPass="keep"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_FUNC_FUNC,0x207); // Stencil comparison function="always"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_FUNC_REF,0); //StencilRef=0
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_FUNC_MASK,0xFFFFFFFF); //StencilMask=0xFFFFFFFF
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_MASK,0xFFFFFFFF); //StencilWriteMask=0xFFFFFFFF
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_BLEND_EQUATION,0x8006); //Blend operator="add"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_BLEND_COLOR,0); //BlendColor=0x000000
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_SWATHWIDTH,4); //SwathWidth=128
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_POLYGON_OFFSET_FACTOR,0); //PolygonOffZSlopeScale=0.0f (because ZBias=0.0f)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_POLYGON_OFFSET_UNITS,0); //PolygonOffZOffset=0.0f (because ZBias=0.0f)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_POLYGON_OFFSET_POINT_ENABLE,0); //PtOffEnable=FALSE (because ZBias=0.0f)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_POLYGON_OFFSET_LINE_ENABLE,0); //WireFrameOffEnable=FALSE (because ZBias=0.0f)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_POLYGON_OFFSET_FILL_ENABLE,0); //SolidOffEnable=FALSE (because ZBias=0.0f)
     pb_end(p);
 
     //various intial settings (complex states)
     p=pb_begin();
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_VERTEX_BLEND_ENABLE,0); p+=2; //VertexBlend="disable"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FOG_COLOR,0); p+=2; //FogColor=0x000000
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_POLYGON_MODE_FRONT,0x1B02,0x1B02); p+=3; //FillMode="solid" BackFillMode="point"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_NORMALIZE_ENABLE,0); p+=2; //NormalizeNormals=FALSE
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_OP_FAIL,0x1E00); p+=2; //StencilFail="keep"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FRONT_FACE,0x900); p+=2; //FrontFace="clockwise"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_CULL_FACE_ENABLE,1); p+=2;//CullModeEnable=TRUE
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_CULL_FACE,0x405); p+=2; //CullMode="FrontFace opposite" (counterclockwise)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_COLOR_LOGIC_OP_ENABLE,0); p+=2; //Logic operator="none"
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_LINE_SMOOTH_ENABLE,0,0); p+=3; //EdgeAntiAlias=0
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_MULTISAMPLE,0xFFFF0001); p+=2; //MultiSampleAntiAliasing=TRUE & MultiSampleMask=0xFFFF
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_SHADOW_FUNC_FUNC,0); p+=2; //Shadow comparison function="never"
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_LINE_WIDTH,(DWORD)(1.0f*8.0f*pb_GlobalScale+0.5f)); p+=2; //LineWidth=1.0f =>8 (0-511)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); p+=2; //prepare subprogram call (wait/makespace, will obtain null status)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,1); p+=2; //set parameter for subprogram (TRUE)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETNOISE); p+=2; //call subprogID PB_SETNOISE: Dxt1NoiseEnable=TRUE
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_CULL_ENABLE,3); p+=2; //bit0:OcclusionCullEnable=TRUE & bit1:StencilCullEnable=TRUE
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); p+=2; //prepare subprogram call (wait/makespace, will obtain null status)
-    pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PGRAPH_DEBUG_5,NV_PGRAPH_DEBUG_5_ZCULL_SPARE2_ENABLED); p+=3; //set parameters A & B: DoNotCullUncompressed=FALSE (|8 otherwise)
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2; //calls subprogID PB_SETOUTER: does VIDEOREG(ParamA)=ParamB
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_VERTEX_BLEND_ENABLE,0); //VertexBlend="disable"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FOG_COLOR,0); //FogColor=0x000000
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_POLYGON_MODE_FRONT,0x1B02,0x1B02); //FillMode="solid" BackFillMode="point"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_NORMALIZE_ENABLE,0); //NormalizeNormals=FALSE
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STENCIL_OP_FAIL,0x1E00); //StencilFail="keep"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FRONT_FACE,0x900); //FrontFace="clockwise"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_CULL_FACE_ENABLE,1);//CullModeEnable=TRUE
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_CULL_FACE,0x405); //CullMode="FrontFace opposite" (counterclockwise)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_COLOR_LOGIC_OP_ENABLE,0); //Logic operator="none"
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_LINE_SMOOTH_ENABLE,0,0); //EdgeAntiAlias=0
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_MULTISAMPLE,0xFFFF0001); //MultiSampleAntiAliasing=TRUE & MultiSampleMask=0xFFFF
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_SHADOW_FUNC_FUNC,0); //Shadow comparison function="never"
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_LINE_WIDTH,(DWORD)(1.0f*8.0f*pb_GlobalScale+0.5f)); //LineWidth=1.0f =>8 (0-511)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); //prepare subprogram call (wait/makespace, will obtain null status)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,1); //set parameter for subprogram (TRUE)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETNOISE); //call subprogID PB_SETNOISE: Dxt1NoiseEnable=TRUE
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_CULL_ENABLE,3); //bit0:OcclusionCullEnable=TRUE & bit1:StencilCullEnable=TRUE
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); //prepare subprogram call (wait/makespace, will obtain null status)
+    p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PGRAPH_DEBUG_5,NV_PGRAPH_DEBUG_5_ZCULL_SPARE2_ENABLED); //set parameters A & B: DoNotCullUncompressed=FALSE (|8 otherwise)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); //calls subprogID PB_SETOUTER: does VIDEOREG(ParamA)=ParamB
     if (VIDEOREG(NV_PBUS_ROM_VERSION)&NV_PBUS_ROM_VERSION_MASK)
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PGRAPH_UNKNOWN_400B80,(0x45EAD10F&~0x18100000)); //RopZCmpAlwaysRead=FALSE (bit27) & RopZRead=FALSE (bit20)
+        p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PGRAPH_UNKNOWN_400B80,(0x45EAD10F&~0x18100000)); //RopZCmpAlwaysRead=FALSE (bit27) & RopZRead=FALSE (bit20)
     else
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PGRAPH_UNKNOWN_400B80,(0x45EAD10E&~0x18100000));
-    p+=3;
-    pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); p+=2; //calls subprogID PB_SETOUTER: does VIDEOREG(ParamA)=ParamB
+        p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PGRAPH_UNKNOWN_400B80,(0x45EAD10E&~0x18100000));
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_SETOUTER); //calls subprogID PB_SETOUTER: does VIDEOREG(ParamA)=ParamB
     pb_end(p);
 
 
     //various intial settings (texture stages states)
     p=pb_begin();
-    pb_push1(p,0x1b68,0); p+=2; //texture stage 1 BumpEnvMat00=0.0f (stage +1 because no pixel shader used yet)
-    pb_push1(p,0x1b6c,0); p+=2; //texture stage 1 BumpEnvMat01=0.0f
-    pb_push1(p,0x1b70,0); p+=2;//texture stage 1 BumpEnvMat11=0.0f
-    pb_push1(p,0x1b74,0); p+=2; //texture stage 1 BumpEnvMat10=0.0f
-    pb_push1(p,0x1b78,0); p+=2; //texture stage 1 BumpEnvMatLightScale=0.0f
-    pb_push1(p,0x1b7c,0); p+=2; //texture stage 1 BumpEnvMatLightOffset=0.0f
-    pb_push3(p,0x03c0,0,0,0); p+=4; //texture stages 0 TexCoordIndex="passthru"
-    pb_push1(p,0x1b24,0); p+=2; //texture stage 0 BorderColor=0x000000
-    pb_push1(p,0x0ae0,0); p+=2; //texture stage 0 ColorKeyColor=0x000000
-    pb_push1(p,0x1ba8,0); p+=2; //texture stage 2 BumpEnvMat00=0.0f (stage +1 because no pixel shader used yet)
-    pb_push1(p,0x1bac,0); p+=2; //texture stage 2 BumpEnvMat01=0.0f
-    pb_push1(p,0x1bb0,0); p+=2;//texture stage 2 BumpEnvMat11=0.0f
-    pb_push1(p,0x1bb4,0); p+=2; //texture stage 2 BumpEnvMat10=0.0f
-    pb_push1(p,0x1bb8,0); p+=2; //texture stage 2 BumpEnvMatLightScale=0.0f
-    pb_push1(p,0x1bbc,0); p+=2; //texture stage 2 BumpEnvMatLightOffset=0.0f
-    pb_push3(p,0x03d0,0,0,0); p+=4; //texture stages 1 TexCoordIndex="passthru"
-    pb_push1(p,0x1b64,0); p+=2; //texture stage 1 BorderColor=0x000000
-    pb_push1(p,0x0ae4,0); p+=2; //texture stage 1 ColorKeyColor=0x000000
-    pb_push1(p,0x1be8,0); p+=2; //texture stage 3 BumpEnvMat00=0.0f (stage +1 because no pixel shader used yet)
-    pb_push1(p,0x1bec,0); p+=2; //texture stage 3 BumpEnvMat01=0.0f
-    pb_push1(p,0x1bf0,0); p+=2;//texture stage 3 BumpEnvMat11=0.0f
-    pb_push1(p,0x1bf4,0); p+=2; //texture stage 3 BumpEnvMat10=0.0f
-    pb_push1(p,0x1bf8,0); p+=2; //texture stage 3 BumpEnvMatLightScale=0.0f
-    pb_push1(p,0x1bfc,0); p+=2; //texture stage 3 BumpEnvMatLightOffset=0.0f
-    pb_push3(p,0x03e0,0,0,0); p+=4; //texture stages 2 TexCoordIndex="passthru"
-    pb_push1(p,0x1ba4,0); p+=2; //texture stage 2 BorderColor=0x000000
-    pb_push1(p,0x0ae8,0); p+=2; //texture stage 2 ColorKeyColor=0x000000
-    pb_push3(p,0x03f0,0,0,0); p+=4; //texture stages 3 TexCoordIndex="passthru"
-    pb_push1(p,0x1be4,0); p+=2; //texture stage 3 BorderColor=0x000000
-    pb_push1(p,0x0aec,0); p+=2; //texture stage 3 ColorKeyColor=0x000000
+    p=pb_push1(p,0x1b68,0); //texture stage 1 BumpEnvMat00=0.0f (stage +1 because no pixel shader used yet)
+    p=pb_push1(p,0x1b6c,0); //texture stage 1 BumpEnvMat01=0.0f
+    p=pb_push1(p,0x1b70,0);//texture stage 1 BumpEnvMat11=0.0f
+    p=pb_push1(p,0x1b74,0); //texture stage 1 BumpEnvMat10=0.0f
+    p=pb_push1(p,0x1b78,0); //texture stage 1 BumpEnvMatLightScale=0.0f
+    p=pb_push1(p,0x1b7c,0); //texture stage 1 BumpEnvMatLightOffset=0.0f
+    p=pb_push3(p,0x03c0,0,0,0); //texture stages 0 TexCoordIndex="passthru"
+    p=pb_push1(p,0x1b24,0); //texture stage 0 BorderColor=0x000000
+    p=pb_push1(p,0x0ae0,0); //texture stage 0 ColorKeyColor=0x000000
+    p=pb_push1(p,0x1ba8,0); //texture stage 2 BumpEnvMat00=0.0f (stage +1 because no pixel shader used yet)
+    p=pb_push1(p,0x1bac,0); //texture stage 2 BumpEnvMat01=0.0f
+    p=pb_push1(p,0x1bb0,0);//texture stage 2 BumpEnvMat11=0.0f
+    p=pb_push1(p,0x1bb4,0); //texture stage 2 BumpEnvMat10=0.0f
+    p=pb_push1(p,0x1bb8,0); //texture stage 2 BumpEnvMatLightScale=0.0f
+    p=pb_push1(p,0x1bbc,0); //texture stage 2 BumpEnvMatLightOffset=0.0f
+    p=pb_push3(p,0x03d0,0,0,0); //texture stages 1 TexCoordIndex="passthru"
+    p=pb_push1(p,0x1b64,0); //texture stage 1 BorderColor=0x000000
+    p=pb_push1(p,0x0ae4,0); //texture stage 1 ColorKeyColor=0x000000
+    p=pb_push1(p,0x1be8,0); //texture stage 3 BumpEnvMat00=0.0f (stage +1 because no pixel shader used yet)
+    p=pb_push1(p,0x1bec,0); //texture stage 3 BumpEnvMat01=0.0f
+    p=pb_push1(p,0x1bf0,0);//texture stage 3 BumpEnvMat11=0.0f
+    p=pb_push1(p,0x1bf4,0); //texture stage 3 BumpEnvMat10=0.0f
+    p=pb_push1(p,0x1bf8,0); //texture stage 3 BumpEnvMatLightScale=0.0f
+    p=pb_push1(p,0x1bfc,0); //texture stage 3 BumpEnvMatLightOffset=0.0f
+    p=pb_push3(p,0x03e0,0,0,0); //texture stages 2 TexCoordIndex="passthru"
+    p=pb_push1(p,0x1ba4,0); //texture stage 2 BorderColor=0x000000
+    p=pb_push1(p,0x0ae8,0); //texture stage 2 ColorKeyColor=0x000000
+    p=pb_push3(p,0x03f0,0,0,0); //texture stages 3 TexCoordIndex="passthru"
+    p=pb_push1(p,0x1be4,0); //texture stage 3 BorderColor=0x000000
+    p=pb_push1(p,0x0aec,0); //texture stage 3 ColorKeyColor=0x000000
     pb_end(p);
 
     memset((DWORD *)pb_FBAddr[0],0,pb_FBSize);

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -20,8 +20,10 @@
 #include <hal/io.h>
 #include <xboxkrnl/xboxkrnl.h>
 #include <hal/debug.h>
+#ifdef DBG
 #include <stdbool.h>
 #include <assert.h>
+#endif
 
 #include "pbkit.h"
 #include "outer.h"
@@ -34,6 +36,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <assert.h>
 
 //a macro used to build up a valid method
 #define EncodeMethod(subchannel,command,nparam) ((nparam<<18)+(subchannel<<13)+command)
@@ -2294,6 +2297,30 @@ void pb_end(DWORD *pEnd)
 }
 
 
+void pb_pushto(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam)
+{
+#ifdef DBG
+    if (p!=pb_PushNext)
+    {
+        debugPrint("pb_push_to: new write address invalid or not following previous write addresses\n");
+        assert(false);
+    }
+    if (pb_BeginEndPair==0)
+    {
+        debugPrint("pb_push_to: missing pb_begin earlier\n");
+        assert(false);
+    }
+    pb_PushIndex += 1 + nparam;
+    pb_PushNext += 1 + nparam;
+    if (pb_PushIndex>128)
+    {
+        debugPrint("pb_push_to: begin-end block musn't exceed 128 dwords\n");
+        assert(false);
+    }
+#endif
+
+    *(p+0)=EncodeMethod(subchannel,command,nparam);
+}
 
 void pb_push1to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1)
 {
@@ -2357,6 +2384,10 @@ void pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD p
     *(p+4)=param4;
 }
 
+void pb_push(DWORD *p, DWORD command, DWORD nparam)
+{
+    pb_pushto(SUBCH_3D,p,command,nparam);
+}
 
 void pb_push1(DWORD *p, DWORD command, DWORD param1)
 {

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -53,8 +53,6 @@ extern "C"
 #define SUBCH_3                 3
 #define SUBCH_4                 4
 
-//fastest way to write a method for subchannel 3D (0)
-#define pb_push(p,command,nparam)       *(p)=((nparam<<18)+command)
 
 void    pb_show_front_screen(void); //shows scene (allows VBL synced screen swapping)
 void    pb_show_debug_screen(void); //shows debug screen (default openxdk+SDL buffer)
@@ -78,10 +76,12 @@ void pb_wait_until_gr_not_busy(void);
 DWORD pb_wait_until_tiles_not_busy(void);
 
 DWORD   *pb_begin(void);    //start a block with this (avoid more than 128 dwords per block)
+void    pb_pushto(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam);
 void    pb_push1to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1); //slow functions but with debug messages
 void    pb_push2to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2);
 void    pb_push3to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3);
 void    pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4);
+void    pb_push(DWORD *p, DWORD command, DWORD nparam);
 void    pb_push1(DWORD *p, DWORD command, DWORD param1); //slow functions but with debug messages (targets SUBCH_3D (0))
 void    pb_push2(DWORD *p, DWORD command, DWORD param1, DWORD param2);
 void    pb_push3(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3);

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -81,6 +81,7 @@ void    pb_push1to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1); //s
 void    pb_push2to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2);
 void    pb_push3to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3);
 void    pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4);
+void    pb_push4fto(DWORD subchannel, DWORD *p, DWORD command, float param1, float param2, float param3, float param4);
 void    pb_push(DWORD *p, DWORD command, DWORD nparam);
 void    pb_push1(DWORD *p, DWORD command, DWORD param1); //slow functions but with debug messages (targets SUBCH_3D (0))
 void    pb_push2(DWORD *p, DWORD command, DWORD param1, DWORD param2);

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -111,9 +111,9 @@ DWORD   pb_back_buffer_width(void);
 DWORD   pb_back_buffer_height(void);
 DWORD   pb_back_buffer_pitch(void);
 
-void    pb_fill(int x,int y,int w,int h, DWORD color);  //rectangle fill
+void    pb_fill(int x,int y,int w,int h, DWORD color) __attribute__ ((deprecated));  //rectangle fill
 
-void    pb_set_viewport(int dwx,int dwy,int width,int height,float zmin,float zmax);
+void    pb_set_viewport(int dwx,int dwy,int width,int height,float zmin,float zmax) __attribute__ ((deprecated));
 
 int pb_busy(void);
 

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -76,12 +76,12 @@ void pb_wait_until_gr_not_busy(void);
 DWORD pb_wait_until_tiles_not_busy(void);
 
 DWORD   *pb_begin(void);    //start a block with this (avoid more than 128 dwords per block)
-inline DWORD   *pb_pushto(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam);
-inline DWORD   *pb_push1to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1);
-inline DWORD   *pb_push2to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2);
-inline DWORD   *pb_push3to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3);
-inline DWORD   *pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4);
-inline DWORD   *pb_push4fto(DWORD subchannel, DWORD *p, DWORD command, float param1, float param2, float param3, float param4);
+inline DWORD   *pb_push_to(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam);
+inline DWORD   *pb_push1_to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1);
+inline DWORD   *pb_push2_to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2);
+inline DWORD   *pb_push3_to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3);
+inline DWORD   *pb_push4_to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4);
+inline DWORD   *pb_push4f_to(DWORD subchannel, DWORD *p, DWORD command, float param1, float param2, float param3, float param4);
 inline DWORD   *pb_push(DWORD *p, DWORD command, DWORD nparam);
 inline DWORD   *pb_push1(DWORD *p, DWORD command, DWORD param1);
 inline DWORD   *pb_push2(DWORD *p, DWORD command, DWORD param1, DWORD param2);

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -76,19 +76,19 @@ void pb_wait_until_gr_not_busy(void);
 DWORD pb_wait_until_tiles_not_busy(void);
 
 DWORD   *pb_begin(void);    //start a block with this (avoid more than 128 dwords per block)
-void    pb_pushto(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam);
-void    pb_push1to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1); //slow functions but with debug messages
-void    pb_push2to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2);
-void    pb_push3to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3);
-void    pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4);
-void    pb_push4fto(DWORD subchannel, DWORD *p, DWORD command, float param1, float param2, float param3, float param4);
-void    pb_push(DWORD *p, DWORD command, DWORD nparam);
-void    pb_push1(DWORD *p, DWORD command, DWORD param1); //slow functions but with debug messages (targets SUBCH_3D (0))
-void    pb_push2(DWORD *p, DWORD command, DWORD param1, DWORD param2);
-void    pb_push3(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3);
-void    pb_push4(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4);
-void    pb_push4f(DWORD *p, DWORD command, float param1, float param2, float param3, float param4);
-void    pb_push_transposed_matrix(DWORD *p, DWORD command, float *m);
+inline DWORD   *pb_pushto(DWORD subchannel, DWORD *p, DWORD command, DWORD nparam);
+inline DWORD   *pb_push1to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1);
+inline DWORD   *pb_push2to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2);
+inline DWORD   *pb_push3to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3);
+inline DWORD   *pb_push4to(DWORD subchannel, DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4);
+inline DWORD   *pb_push4fto(DWORD subchannel, DWORD *p, DWORD command, float param1, float param2, float param3, float param4);
+inline DWORD   *pb_push(DWORD *p, DWORD command, DWORD nparam);
+inline DWORD   *pb_push1(DWORD *p, DWORD command, DWORD param1);
+inline DWORD   *pb_push2(DWORD *p, DWORD command, DWORD param1, DWORD param2);
+inline DWORD   *pb_push3(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3);
+inline DWORD   *pb_push4(DWORD *p, DWORD command, DWORD param1, DWORD param2, DWORD param3, DWORD param4);
+inline DWORD   *pb_push4f(DWORD *p, DWORD command, float param1, float param2, float param3, float param4);
+inline DWORD   *pb_push_transposed_matrix(DWORD *p, DWORD command, float *m);
 void    pb_end(DWORD *pEnd);    //end a block with this (triggers the data sending to GPU)
 
 void    pb_extra_buffers(int n);//requests additional back buffers (default is 0) (call it before pb_init)

--- a/lib/xgu/nv2a_regs.h
+++ b/lib/xgu/nv2a_regs.h
@@ -1,0 +1,1321 @@
+/*
+ * QEMU Geforce NV2A register definitions
+ *
+ * Copyright (c) 2012 espes
+ * Copyright (c) 2015 Jannik Vogel
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef HW_NV2A_REGS_H
+#define HW_NV2A_REGS_H
+
+#define NV_NUM_BLOCKS 21
+#define NV_PMC          0   /* card master control */
+#define NV_PBUS         1   /* bus control */
+#define NV_PFIFO        2   /* MMIO and DMA FIFO submission to PGRAPH and VPE */
+#define NV_PFIFO_CACHE  3
+#define NV_PRMA         4   /* access to BAR0/BAR1 from real mode */
+#define NV_PVIDEO       5   /* video overlay */
+#define NV_PTIMER       6   /* time measurement and time-based alarms */
+#define NV_PCOUNTER     7   /* performance monitoring counters */
+#define NV_PVPE         8   /* MPEG2 decoding engine */
+#define NV_PTV          9   /* TV encoder */
+#define NV_PRMFB        10  /* aliases VGA memory window */
+#define NV_PRMVIO       11  /* aliases VGA sequencer and graphics controller registers */
+#define NV_PFB          12  /* memory interface */
+#define NV_PSTRAPS      13  /* straps readout / override */
+#define NV_PGRAPH       14  /* accelerated 2d/3d drawing engine */
+#define NV_PCRTC        15  /* more CRTC controls */
+#define NV_PRMCIO       16  /* aliases VGA CRTC and attribute controller registers */
+#define NV_PRAMDAC      17  /* RAMDAC, cursor, and PLL control */
+#define NV_PRMDIO       18  /* aliases VGA palette registers */
+#define NV_PRAMIN       19  /* RAMIN access */
+#define NV_USER         20  /* PFIFO MMIO and DMA submission area */
+
+#define NV_PMC_BOOT_0                                    0x00000000
+#define NV_PMC_INTR_0                                    0x00000100
+#   define NV_PMC_INTR_0_PFIFO                                 (1 << 8)
+#   define NV_PMC_INTR_0_PGRAPH                               (1 << 12)
+#   define NV_PMC_INTR_0_PCRTC                                (1 << 24)
+#   define NV_PMC_INTR_0_PBUS                                 (1 << 28)
+#   define NV_PMC_INTR_0_SOFTWARE                             (1 << 31)
+#define NV_PMC_INTR_EN_0                                 0x00000140
+#   define NV_PMC_INTR_EN_0_HARDWARE                            1
+#   define NV_PMC_INTR_EN_0_SOFTWARE                            2
+#define NV_PMC_ENABLE                                    0x00000200
+#   define NV_PMC_ENABLE_PFIFO                                 (1 << 8)
+#   define NV_PMC_ENABLE_PGRAPH                               (1 << 12)
+
+
+/* These map approximately to the pci registers */
+#define NV_PBUS_PCI_NV_0                                 0x00000800
+#   define NV_PBUS_PCI_NV_0_VENDOR_ID                         0x0000FFFF
+#   define NV_CONFIG_PCI_NV_0_DEVICE_ID                       0xFFFF0000
+#define NV_PBUS_PCI_NV_1                                 0x00000804
+#define NV_PBUS_PCI_NV_2                                 0x00000808
+#   define NV_PBUS_PCI_NV_2_REVISION_ID                       0x000000FF
+#   define NV_PBUS_PCI_NV_2_CLASS_CODE                        0xFFFFFF00
+
+
+#define NV_PFIFO_INTR_0                                  0x00000100
+#   define NV_PFIFO_INTR_0_CACHE_ERROR                          (1 << 0)
+#   define NV_PFIFO_INTR_0_RUNOUT                               (1 << 4)
+#   define NV_PFIFO_INTR_0_RUNOUT_OVERFLOW                      (1 << 8)
+#   define NV_PFIFO_INTR_0_DMA_PUSHER                          (1 << 12)
+#   define NV_PFIFO_INTR_0_DMA_PT                              (1 << 16)
+#   define NV_PFIFO_INTR_0_SEMAPHORE                           (1 << 20)
+#   define NV_PFIFO_INTR_0_ACQUIRE_TIMEOUT                     (1 << 24)
+#define NV_PFIFO_INTR_EN_0                               0x00000140
+#   define NV_PFIFO_INTR_EN_0_CACHE_ERROR                       (1 << 0)
+#   define NV_PFIFO_INTR_EN_0_RUNOUT                            (1 << 4)
+#   define NV_PFIFO_INTR_EN_0_RUNOUT_OVERFLOW                   (1 << 8)
+#   define NV_PFIFO_INTR_EN_0_DMA_PUSHER                       (1 << 12)
+#   define NV_PFIFO_INTR_EN_0_DMA_PT                           (1 << 16)
+#   define NV_PFIFO_INTR_EN_0_SEMAPHORE                        (1 << 20)
+#   define NV_PFIFO_INTR_EN_0_ACQUIRE_TIMEOUT                  (1 << 24)
+#define NV_PFIFO_RAMHT                                   0x00000210
+#   define NV_PFIFO_RAMHT_BASE_ADDRESS                        0x000001F0
+#   define NV_PFIFO_RAMHT_SIZE                                0x00030000
+#       define NV_PFIFO_RAMHT_SIZE_4K                             0
+#       define NV_PFIFO_RAMHT_SIZE_8K                             1
+#       define NV_PFIFO_RAMHT_SIZE_16K                            2
+#       define NV_PFIFO_RAMHT_SIZE_32K                            3
+#   define NV_PFIFO_RAMHT_SEARCH                              0x03000000
+#       define NV_PFIFO_RAMHT_SEARCH_16                           0
+#       define NV_PFIFO_RAMHT_SEARCH_32                           1
+#       define NV_PFIFO_RAMHT_SEARCH_64                           2
+#       define NV_PFIFO_RAMHT_SEARCH_128                          3
+#define NV_PFIFO_RAMFC                                   0x00000214
+#   define NV_PFIFO_RAMFC_BASE_ADDRESS1                       0x000001FC
+#   define NV_PFIFO_RAMFC_SIZE                                0x00010000
+#   define NV_PFIFO_RAMFC_BASE_ADDRESS2                       0x00FE0000
+#define NV_PFIFO_RAMRO                                   0x00000218
+#   define NV_PFIFO_RAMRO_BASE_ADDRESS                        0x000001FE
+#   define NV_PFIFO_RAMRO_SIZE                                0x00010000
+#define NV_PFIFO_RUNOUT_STATUS                           0x00000400
+#   define NV_PFIFO_RUNOUT_STATUS_RANOUT                       (1 << 0)
+#   define NV_PFIFO_RUNOUT_STATUS_LOW_MARK                     (1 << 4)
+#   define NV_PFIFO_RUNOUT_STATUS_HIGH_MARK                    (1 << 8)
+#define NV_PFIFO_MODE                                    0x00000504
+#define NV_PFIFO_DMA                                     0x00000508
+#define NV_PFIFO_CACHE1_PUSH0                            0x00001200
+#   define NV_PFIFO_CACHE1_PUSH0_ACCESS                         (1 << 0)
+#define NV_PFIFO_CACHE1_PUSH1                            0x00001204
+#   define NV_PFIFO_CACHE1_PUSH1_CHID                         0x0000001F
+#   define NV_PFIFO_CACHE1_PUSH1_MODE                         0x00000100
+#       define NV_PFIFO_CACHE1_PUSH1_MODE_PIO                     0
+#       define NV_PFIFO_CACHE1_PUSH1_MODE_DMA                     1
+#define NV_PFIFO_CACHE1_PUT                              0x00001210
+#define NV_PFIFO_CACHE1_STATUS                           0x00001214
+#   define NV_PFIFO_CACHE1_STATUS_LOW_MARK                      (1 << 4)
+#   define NV_PFIFO_CACHE1_STATUS_HIGH_MARK                     (1 << 8)
+#define NV_PFIFO_CACHE1_DMA_PUSH                         0x00001220
+#   define NV_PFIFO_CACHE1_DMA_PUSH_ACCESS                      (1 << 0)
+#   define NV_PFIFO_CACHE1_DMA_PUSH_STATE                       (1 << 4)
+#   define NV_PFIFO_CACHE1_DMA_PUSH_BUFFER                      (1 << 8)
+#   define NV_PFIFO_CACHE1_DMA_PUSH_STATUS                     (1 << 12)
+#   define NV_PFIFO_CACHE1_DMA_PUSH_ACQUIRE                    (1 << 16)
+#define NV_PFIFO_CACHE1_DMA_FETCH                        0x00001224
+#   define NV_PFIFO_CACHE1_DMA_FETCH_TRIG                     0x000000F8
+#   define NV_PFIFO_CACHE1_DMA_FETCH_SIZE                     0x0000E000
+#   define NV_PFIFO_CACHE1_DMA_FETCH_MAX_REQS                 0x001F0000
+#define NV_PFIFO_CACHE1_DMA_STATE                        0x00001228
+#   define NV_PFIFO_CACHE1_DMA_STATE_METHOD_TYPE                (1 << 0)
+#       define NV_PFIFO_CACHE1_DMA_STATE_METHOD_TYPE_INC          0
+#       define NV_PFIFO_CACHE1_DMA_STATE_METHOD_TYPE_NON_INC      1
+#   define NV_PFIFO_CACHE1_DMA_STATE_METHOD                   0x00001FFC
+#   define NV_PFIFO_CACHE1_DMA_STATE_SUBCHANNEL               0x0000E000
+#   define NV_PFIFO_CACHE1_DMA_STATE_METHOD_COUNT             0x1FFC0000
+#   define NV_PFIFO_CACHE1_DMA_STATE_ERROR                    0xE0000000
+#       define NV_PFIFO_CACHE1_DMA_STATE_ERROR_NONE               0
+#       define NV_PFIFO_CACHE1_DMA_STATE_ERROR_CALL               1
+#       define NV_PFIFO_CACHE1_DMA_STATE_ERROR_NON_CACHE          2
+#       define NV_PFIFO_CACHE1_DMA_STATE_ERROR_RETURN             3
+#       define NV_PFIFO_CACHE1_DMA_STATE_ERROR_RESERVED_CMD       4
+#       define NV_PFIFO_CACHE1_DMA_STATE_ERROR_PROTECTION         6
+#define NV_PFIFO_CACHE1_DMA_INSTANCE                     0x0000122C
+#   define NV_PFIFO_CACHE1_DMA_INSTANCE_ADDRESS               0x0000FFFF
+#define NV_PFIFO_CACHE1_DMA_PUT                          0x00001240
+#define NV_PFIFO_CACHE1_DMA_GET                          0x00001244
+#define NV_PFIFO_CACHE1_REF                              0x00001248
+#define NV_PFIFO_CACHE1_DMA_SUBROUTINE                   0x0000124C
+#   define NV_PFIFO_CACHE1_DMA_SUBROUTINE_RETURN_OFFSET       0x1FFFFFFC
+#   define NV_PFIFO_CACHE1_DMA_SUBROUTINE_STATE                (1 << 0)
+#define NV_PFIFO_CACHE1_PULL0                            0x00001250
+#   define NV_PFIFO_CACHE1_PULL0_ACCESS                        (1 << 0)
+#define NV_PFIFO_CACHE1_PULL1                            0x00001254
+#   define NV_PFIFO_CACHE1_PULL1_ENGINE                       0x00000003
+#define NV_PFIFO_CACHE1_GET                              0x00001270
+#define NV_PFIFO_CACHE1_ENGINE                           0x00001280
+#define NV_PFIFO_CACHE1_DMA_DCOUNT                       0x000012A0
+#   define NV_PFIFO_CACHE1_DMA_DCOUNT_VALUE                   0x00001FFC
+#define NV_PFIFO_CACHE1_DMA_GET_JMP_SHADOW               0x000012A4
+#   define NV_PFIFO_CACHE1_DMA_GET_JMP_SHADOW_OFFSET          0x1FFFFFFC
+#define NV_PFIFO_CACHE1_DMA_RSVD_SHADOW                  0x000012A8
+#define NV_PFIFO_CACHE1_DMA_DATA_SHADOW                  0x000012AC
+#define NV_PFIFO_CACHE1_METHOD                           0x00001800
+#   define NV_PFIFO_CACHE1_METHOD_TYPE                         (1 << 0)
+#   define NV_PFIFO_CACHE1_METHOD_ADDRESS                     0x00001FFC
+#   define NV_PFIFO_CACHE1_METHOD_SUBCHANNEL                  0x0000E000
+#define NV_PFIFO_CACHE1_DATA                             0x00001804
+
+#define NV_PGRAPH_DEBUG_3                                0x0000008C
+#   define NV_PGRAPH_DEBUG_3_HW_CONTEXT_SWITCH                (1 << 2)
+#define NV_PGRAPH_INTR                                   0x00000100
+#   define NV_PGRAPH_INTR_NOTIFY                              (1 << 0)
+#   define NV_PGRAPH_INTR_MISSING_HW                          (1 << 4)
+#   define NV_PGRAPH_INTR_TLB_PRESENT_DMA_R                   (1 << 6)
+#   define NV_PGRAPH_INTR_TLB_PRESENT_DMA_W                   (1 << 7)
+#   define NV_PGRAPH_INTR_TLB_PRESENT_TEX_A                   (1 << 8)
+#   define NV_PGRAPH_INTR_TLB_PRESENT_TEX_B                   (1 << 9)
+#   define NV_PGRAPH_INTR_TLB_PRESENT_VTX                    (1 << 10)
+#   define NV_PGRAPH_INTR_CONTEXT_SWITCH                     (1 << 12)
+#   define NV_PGRAPH_INTR_STATE3D                            (1 << 13)
+#   define NV_PGRAPH_INTR_BUFFER_NOTIFY                      (1 << 16)
+#   define NV_PGRAPH_INTR_ERROR                              (1 << 20)
+#   define NV_PGRAPH_INTR_SINGLE_STEP                        (1 << 24)
+#define NV_PGRAPH_NSOURCE                                0x00000108
+#   define NV_PGRAPH_NSOURCE_NOTIFICATION                     (1 << 0)
+#define NV_PGRAPH_INTR_EN                                0x00000140
+#   define NV_PGRAPH_INTR_EN_NOTIFY                           (1 << 0)
+#   define NV_PGRAPH_INTR_EN_MISSING_HW                       (1 << 4)
+#   define NV_PGRAPH_INTR_EN_TLB_PRESENT_DMA_R                (1 << 6)
+#   define NV_PGRAPH_INTR_EN_TLB_PRESENT_DMA_W                (1 << 7)
+#   define NV_PGRAPH_INTR_EN_TLB_PRESENT_TEX_A                (1 << 8)
+#   define NV_PGRAPH_INTR_EN_TLB_PRESENT_TEX_B                (1 << 9)
+#   define NV_PGRAPH_INTR_EN_TLB_PRESENT_VTX                 (1 << 10)
+#   define NV_PGRAPH_INTR_EN_CONTEXT_SWITCH                  (1 << 12)
+#   define NV_PGRAPH_INTR_EN_STATE3D                         (1 << 13)
+#   define NV_PGRAPH_INTR_EN_BUFFER_NOTIFY                   (1 << 16)
+#   define NV_PGRAPH_INTR_EN_ERROR                           (1 << 20)
+#   define NV_PGRAPH_INTR_EN_SINGLE_STEP                     (1 << 24)
+#define NV_PGRAPH_CTX_CONTROL                            0x00000144
+#   define NV_PGRAPH_CTX_CONTROL_MINIMUM_TIME                 0x00000003
+#   define NV_PGRAPH_CTX_CONTROL_TIME                           (1 << 8)
+#   define NV_PGRAPH_CTX_CONTROL_CHID                          (1 << 16)
+#   define NV_PGRAPH_CTX_CONTROL_CHANGE                        (1 << 20)
+#   define NV_PGRAPH_CTX_CONTROL_SWITCHING                     (1 << 24)
+#   define NV_PGRAPH_CTX_CONTROL_DEVICE                        (1 << 28)
+#define NV_PGRAPH_CTX_USER                               0x00000148
+#   define NV_PGRAPH_CTX_USER_CHANNEL_3D                        (1 << 0)
+#   define NV_PGRAPH_CTX_USER_CHANNEL_3D_VALID                  (1 << 4)
+#   define NV_PGRAPH_CTX_USER_SUBCH                           0x0000E000
+#   define NV_PGRAPH_CTX_USER_CHID                            0x1F000000
+#   define NV_PGRAPH_CTX_USER_SINGLE_STEP                      (1 << 31)
+#define NV_PGRAPH_CTX_SWITCH1                            0x0000014C
+#   define NV_PGRAPH_CTX_SWITCH1_GRCLASS                      0x000000FF
+#   define NV_PGRAPH_CTX_SWITCH1_CHROMA_KEY                    (1 << 12)
+#   define NV_PGRAPH_CTX_SWITCH1_SWIZZLE                       (1 << 14)
+#   define NV_PGRAPH_CTX_SWITCH1_PATCH_CONFIG                 0x00038000
+#   define NV_PGRAPH_CTX_SWITCH1_SYNCHRONIZE                   (1 << 18)
+#   define NV_PGRAPH_CTX_SWITCH1_ENDIAN_MODE                   (1 << 19)
+#   define NV_PGRAPH_CTX_SWITCH1_CLASS_TYPE                    (1 << 22)
+#   define NV_PGRAPH_CTX_SWITCH1_SINGLE_STEP                   (1 << 23)
+#   define NV_PGRAPH_CTX_SWITCH1_PATCH_STATUS                  (1 << 24)
+#   define NV_PGRAPH_CTX_SWITCH1_CONTEXT_SURFACE0              (1 << 25)
+#   define NV_PGRAPH_CTX_SWITCH1_CONTEXT_SURFACE1              (1 << 26)
+#   define NV_PGRAPH_CTX_SWITCH1_CONTEXT_PATTERN               (1 << 27)
+#   define NV_PGRAPH_CTX_SWITCH1_CONTEXT_ROP                   (1 << 28)
+#   define NV_PGRAPH_CTX_SWITCH1_CONTEXT_BETA1                 (1 << 29)
+#   define NV_PGRAPH_CTX_SWITCH1_CONTEXT_BETA4                 (1 << 30)
+#   define NV_PGRAPH_CTX_SWITCH1_VOLATILE_RESET                (1 << 31)
+#define NV_PGRAPH_CTX_SWITCH2                            0x00000150
+#define NV_PGRAPH_CTX_SWITCH3                            0x00000154
+#define NV_PGRAPH_CTX_SWITCH4                            0x00000158
+#   define NV_PGRAPH_CTX_SWITCH4_USER_INSTANCE                0x0000FFFF
+#define NV_PGRAPH_CTX_SWITCH5                            0x0000015C
+#define NV_PGRAPH_CTX_CACHE1                             0x00000160
+#define NV_PGRAPH_CTX_CACHE2                             0x00000180
+#define NV_PGRAPH_CTX_CACHE3                             0x000001A0
+#define NV_PGRAPH_CTX_CACHE4                             0x000001C0
+#define NV_PGRAPH_CTX_CACHE5                             0x000001E0
+#define NV_PGRAPH_TRAPPED_ADDR                           0x00000704
+#   define NV_PGRAPH_TRAPPED_ADDR_MTHD                        0x00001FFF
+#   define NV_PGRAPH_TRAPPED_ADDR_SUBCH                       0x00070000
+#   define NV_PGRAPH_TRAPPED_ADDR_CHID                        0x01F00000
+#   define NV_PGRAPH_TRAPPED_ADDR_DHV                         0x10000000
+#define NV_PGRAPH_TRAPPED_DATA_LOW                       0x00000708
+#define NV_PGRAPH_SURFACE                                0x00000710
+#   define NV_PGRAPH_SURFACE_WRITE_3D                         0x00700000
+#   define NV_PGRAPH_SURFACE_READ_3D                          0x07000000
+#   define NV_PGRAPH_SURFACE_MODULO_3D                        0x70000000
+#define NV_PGRAPH_INCREMENT                              0x0000071C
+#   define NV_PGRAPH_INCREMENT_READ_BLIT                        (1 << 0)
+#   define NV_PGRAPH_INCREMENT_READ_3D                          (1 << 1)
+#define NV_PGRAPH_FIFO                                   0x00000720
+#   define NV_PGRAPH_FIFO_ACCESS                                (1 << 0)
+#define NV_PGRAPH_CHANNEL_CTX_TABLE                      0x00000780
+#   define NV_PGRAPH_CHANNEL_CTX_TABLE_INST                   0x0000FFFF
+#define NV_PGRAPH_CHANNEL_CTX_POINTER                    0x00000784
+#   define NV_PGRAPH_CHANNEL_CTX_POINTER_INST                 0x0000FFFF
+#define NV_PGRAPH_CHANNEL_CTX_TRIGGER                    0x00000788
+#   define NV_PGRAPH_CHANNEL_CTX_TRIGGER_READ_IN                (1 << 0)
+#   define NV_PGRAPH_CHANNEL_CTX_TRIGGER_WRITE_OUT              (1 << 1)
+#define NV_PGRAPH_PATT_COLOR0                            0x00000B10
+#define NV_PGRAPH_CSV0_D                                 0x00000FB4
+#   define NV_PGRAPH_CSV0_D_LIGHTS                              0x0000FFFF
+#   define NV_PGRAPH_CSV0_D_LIGHT0                              0x00000003
+#       define NV_PGRAPH_CSV0_D_LIGHT0_OFF                          0
+#       define NV_PGRAPH_CSV0_D_LIGHT0_INFINITE                     1
+#       define NV_PGRAPH_CSV0_D_LIGHT0_LOCAL                        2
+#       define NV_PGRAPH_CSV0_D_LIGHT0_SPOT                         3
+#   define NV_PGRAPH_CSV0_D_RANGE_MODE                          (1 << 18)
+#   define NV_PGRAPH_CSV0_D_FOGENABLE                           (1 << 19)
+#   define NV_PGRAPH_CSV0_D_TEXGEN_REF                          (1 << 20)
+#       define NV_PGRAPH_CSV0_D_TEXGEN_REF_LOCAL_VIEWER             0
+#       define NV_PGRAPH_CSV0_D_TEXGEN_REF_INFINITE_VIEWER          1
+#   define NV_PGRAPH_CSV0_D_FOG_MODE                            (1 << 21)
+#       define NV_PGRAPH_CSV0_D_FOG_MODE_LINEAR                     0
+#       define NV_PGRAPH_CSV0_D_FOG_MODE_EXP                        1
+#   define NV_PGRAPH_CSV0_D_FOGGENMODE                          0x01C00000
+#       define NV_PGRAPH_CSV0_D_FOGGENMODE_SPEC_ALPHA               0
+#       define NV_PGRAPH_CSV0_D_FOGGENMODE_RADIAL                   1
+#       define NV_PGRAPH_CSV0_D_FOGGENMODE_PLANAR                   2
+#       define NV_PGRAPH_CSV0_D_FOGGENMODE_ABS_PLANAR               3
+#       define NV_PGRAPH_CSV0_D_FOGGENMODE_FOG_X                    4
+#   define NV_PGRAPH_CSV0_D_MODE                                0xC0000000
+#   define NV_PGRAPH_CSV0_D_SKIN                                0x1C000000
+#       define NV_PGRAPH_CSV0_D_SKIN_OFF                            0
+#       define NV_PGRAPH_CSV0_D_SKIN_2G                             1
+#       define NV_PGRAPH_CSV0_D_SKIN_2                              2
+#       define NV_PGRAPH_CSV0_D_SKIN_3G                             3
+#       define NV_PGRAPH_CSV0_D_SKIN_3                              4
+#       define NV_PGRAPH_CSV0_D_SKIN_4G                             5
+#       define NV_PGRAPH_CSV0_D_SKIN_4                              6
+#define NV_PGRAPH_CSV0_C                                 0x00000FB8
+#   define NV_PGRAPH_CSV0_C_CHEOPS_PROGRAM_START                0x0000FF00
+#   define NV_PGRAPH_CSV0_C_NORMALIZATION_ENABLE                (1 << 27)
+#   define NV_PGRAPH_CSV0_C_LIGHTING                            (1 << 31)
+#define NV_PGRAPH_CSV1_B                                 0x00000FBC
+#define NV_PGRAPH_CSV1_A                                 0x00000FC0
+#   define NV_PGRAPH_CSV1_A_T0_ENABLE                           (1 << 0)
+#   define NV_PGRAPH_CSV1_A_T0_MODE                             (1 << 1)
+#   define NV_PGRAPH_CSV1_A_T0_TEXTURE                          (1 << 2)
+#       define NV_PGRAPH_CSV1_A_T0_TEXTURE_2D                       0
+#       define NV_PGRAPH_CSV1_A_T0_TEXTURE_3D                       1
+#   define NV_PGRAPH_CSV1_A_T0_S                                0x00000070
+#       define NV_PGRAPH_CSV1_A_T0_S_DISABLE                        0
+#       define NV_PGRAPH_CSV1_A_T0_S_NORMAL_MAP                     4
+#       define NV_PGRAPH_CSV1_A_T0_S_REFLECTION_MAP                 5
+#       define NV_PGRAPH_CSV1_A_T0_S_EYE_LINEAR                     1
+#       define NV_PGRAPH_CSV1_A_T0_S_OBJECT_LINEAR                  2
+#       define NV_PGRAPH_CSV1_A_T0_S_SPHERE_MAP                     3
+#   define NV_PGRAPH_CSV1_A_T0_T                                0x00000380
+#   define NV_PGRAPH_CSV1_A_T0_R                                0x00001C00
+#   define NV_PGRAPH_CSV1_A_T0_Q                                0x0000E000
+#   define NV_PGRAPH_CSV1_A_T1_ENABLE                           (1 << 16)
+#   define NV_PGRAPH_CSV1_A_T1_MODE                             (1 << 17)
+#   define NV_PGRAPH_CSV1_A_T1_TEXTURE                          (1 << 18)
+#   define NV_PGRAPH_CSV1_A_T1_S                                0x00700000
+#   define NV_PGRAPH_CSV1_A_T1_T                                0x03800000
+#   define NV_PGRAPH_CSV1_A_T1_R                                0x1C000000
+#   define NV_PGRAPH_CSV1_A_T1_Q                                0xE0000000
+#define NV_PGRAPH_CHEOPS_OFFSET                          0x00000FC4
+#   define NV_PGRAPH_CHEOPS_OFFSET_PROG_LD_PTR                  0x000000FF
+#   define NV_PGRAPH_CHEOPS_OFFSET_CONST_LD_PTR                 0x0000FF00
+#define NV_PGRAPH_DMA_STATE                              0x00001034
+#define NV_PGRAPH_BLEND                                  0x00001804
+#   define NV_PGRAPH_BLEND_EQN                                  0x00000007
+#   define NV_PGRAPH_BLEND_EN                                   (1 << 3)
+#   define NV_PGRAPH_BLEND_SFACTOR                              0x000000F0
+#       define NV_PGRAPH_BLEND_SFACTOR_ZERO                         0
+#       define NV_PGRAPH_BLEND_SFACTOR_ONE                          1
+#       define NV_PGRAPH_BLEND_SFACTOR_SRC_COLOR                    2
+#       define NV_PGRAPH_BLEND_SFACTOR_ONE_MINUS_SRC_COLOR          3
+#       define NV_PGRAPH_BLEND_SFACTOR_SRC_ALPHA                    4
+#       define NV_PGRAPH_BLEND_SFACTOR_ONE_MINUS_SRC_ALPHA          5
+#       define NV_PGRAPH_BLEND_SFACTOR_DST_ALPHA                    6
+#       define NV_PGRAPH_BLEND_SFACTOR_ONE_MINUS_DST_ALPHA          7
+#       define NV_PGRAPH_BLEND_SFACTOR_DST_COLOR                    8
+#       define NV_PGRAPH_BLEND_SFACTOR_ONE_MINUS_DST_COLOR          9
+#       define NV_PGRAPH_BLEND_SFACTOR_SRC_ALPHA_SATURATE           10
+#       define NV_PGRAPH_BLEND_SFACTOR_CONSTANT_COLOR               12
+#       define NV_PGRAPH_BLEND_SFACTOR_ONE_MINUS_CONSTANT_COLOR     13
+#       define NV_PGRAPH_BLEND_SFACTOR_CONSTANT_ALPHA               14
+#       define NV_PGRAPH_BLEND_SFACTOR_ONE_MINUS_CONSTANT_ALPHA     15
+#   define NV_PGRAPH_BLEND_DFACTOR                              0x00000F00
+#       define NV_PGRAPH_BLEND_DFACTOR_ZERO                         0
+#       define NV_PGRAPH_BLEND_DFACTOR_ONE                          1
+#       define NV_PGRAPH_BLEND_DFACTOR_SRC_COLOR                    2
+#       define NV_PGRAPH_BLEND_DFACTOR_ONE_MINUS_SRC_COLOR          3
+#       define NV_PGRAPH_BLEND_DFACTOR_SRC_ALPHA                    4
+#       define NV_PGRAPH_BLEND_DFACTOR_ONE_MINUS_SRC_ALPHA          5
+#       define NV_PGRAPH_BLEND_DFACTOR_DST_ALPHA                    6
+#       define NV_PGRAPH_BLEND_DFACTOR_ONE_MINUS_DST_ALPHA          7
+#       define NV_PGRAPH_BLEND_DFACTOR_DST_COLOR                    8
+#       define NV_PGRAPH_BLEND_DFACTOR_ONE_MINUS_DST_COLOR          9
+#       define NV_PGRAPH_BLEND_DFACTOR_SRC_ALPHA_SATURATE           10
+#       define NV_PGRAPH_BLEND_DFACTOR_CONSTANT_COLOR               12
+#       define NV_PGRAPH_BLEND_DFACTOR_ONE_MINUS_CONSTANT_COLOR     13
+#       define NV_PGRAPH_BLEND_DFACTOR_CONSTANT_ALPHA               14
+#       define NV_PGRAPH_BLEND_DFACTOR_ONE_MINUS_CONSTANT_ALPHA     15
+#   define NV_PGRAPH_BLEND_LOGICOP_ENABLE                       (1 << 16)
+#   define NV_PGRAPH_BLEND_LOGICOP                              0x0000F000
+#define NV_PGRAPH_BLENDCOLOR                             0x00001808
+#define NV_PGRAPH_BORDERCOLOR0                           0x0000180C
+#define NV_PGRAPH_BORDERCOLOR1                           0x00001810
+#define NV_PGRAPH_BORDERCOLOR2                           0x00001814
+#define NV_PGRAPH_BORDERCOLOR3                           0x00001818
+#define NV_PGRAPH_BUMPOFFSET1                            0x0000184C
+#define NV_PGRAPH_BUMPSCALE1                             0x00001858
+#define NV_PGRAPH_CLEARRECTX                             0x00001864
+#       define NV_PGRAPH_CLEARRECTX_XMIN                          0x00000FFF
+#       define NV_PGRAPH_CLEARRECTX_XMAX                          0x0FFF0000
+#define NV_PGRAPH_CLEARRECTY                             0x00001868
+#       define NV_PGRAPH_CLEARRECTY_YMIN                          0x00000FFF
+#       define NV_PGRAPH_CLEARRECTY_YMAX                          0x0FFF0000
+#define NV_PGRAPH_COLORCLEARVALUE                        0x0000186C
+#define NV_PGRAPH_COMBINEFACTOR0                         0x00001880
+#define NV_PGRAPH_COMBINEFACTOR1                         0x000018A0
+#define NV_PGRAPH_COMBINEALPHAI0                         0x000018C0
+#define NV_PGRAPH_COMBINEALPHAO0                         0x000018E0
+#define NV_PGRAPH_COMBINECOLORI0                         0x00001900
+#define NV_PGRAPH_COMBINECOLORO0                         0x00001920
+#define NV_PGRAPH_COMBINECTL                             0x00001940
+#define NV_PGRAPH_COMBINESPECFOG0                        0x00001944
+#define NV_PGRAPH_COMBINESPECFOG1                        0x00001948
+#define NV_PGRAPH_CONTROL_0                              0x0000194C
+#   define NV_PGRAPH_CONTROL_0_ALPHAREF                         0x000000FF
+#   define NV_PGRAPH_CONTROL_0_ALPHAFUNC                        0x00000F00
+#   define NV_PGRAPH_CONTROL_0_ALPHATESTENABLE                  (1 << 12)
+#   define NV_PGRAPH_CONTROL_0_ZENABLE                          (1 << 14)
+#   define NV_PGRAPH_CONTROL_0_ZFUNC                            0x000F0000
+#       define NV_PGRAPH_CONTROL_0_ZFUNC_NEVER                      0
+#       define NV_PGRAPH_CONTROL_0_ZFUNC_LESS                       1
+#       define NV_PGRAPH_CONTROL_0_ZFUNC_EQUAL                      2
+#       define NV_PGRAPH_CONTROL_0_ZFUNC_LEQUAL                     3
+#       define NV_PGRAPH_CONTROL_0_ZFUNC_GREATER                    4
+#       define NV_PGRAPH_CONTROL_0_ZFUNC_NOTEQUAL                   5
+#       define NV_PGRAPH_CONTROL_0_ZFUNC_GEQUAL                     6
+#       define NV_PGRAPH_CONTROL_0_ZFUNC_ALWAYS                     7
+#   define NV_PGRAPH_CONTROL_0_DITHERENABLE                     (1 << 22)
+#   define NV_PGRAPH_CONTROL_0_Z_PERSPECTIVE_ENABLE             (1 << 23)
+#   define NV_PGRAPH_CONTROL_0_ZWRITEENABLE                     (1 << 24)
+#   define NV_PGRAPH_CONTROL_0_STENCIL_WRITE_ENABLE             (1 << 25)
+#   define NV_PGRAPH_CONTROL_0_ALPHA_WRITE_ENABLE               (1 << 26)
+#   define NV_PGRAPH_CONTROL_0_RED_WRITE_ENABLE                 (1 << 27)
+#   define NV_PGRAPH_CONTROL_0_GREEN_WRITE_ENABLE               (1 << 28)
+#   define NV_PGRAPH_CONTROL_0_BLUE_WRITE_ENABLE                (1 << 29)
+#define NV_PGRAPH_CONTROL_1                              0x00001950
+#   define NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE              (1 << 0)
+#   define NV_PGRAPH_CONTROL_1_STENCIL_FUNC                     0x000000F0
+#       define NV_PGRAPH_CONTROL_1_STENCIL_FUNC_NEVER               0
+#       define NV_PGRAPH_CONTROL_1_STENCIL_FUNC_LESS                1
+#       define NV_PGRAPH_CONTROL_1_STENCIL_FUNC_EQUAL               2
+#       define NV_PGRAPH_CONTROL_1_STENCIL_FUNC_LEQUAL              3
+#       define NV_PGRAPH_CONTROL_1_STENCIL_FUNC_GREATER             4
+#       define NV_PGRAPH_CONTROL_1_STENCIL_FUNC_NOTEQUAL            5
+#       define NV_PGRAPH_CONTROL_1_STENCIL_FUNC_GEQUAL              6
+#       define NV_PGRAPH_CONTROL_1_STENCIL_FUNC_ALWAYS              7
+#   define NV_PGRAPH_CONTROL_1_STENCIL_REF                      0x0000FF00
+#   define NV_PGRAPH_CONTROL_1_STENCIL_MASK_READ                0x00FF0000
+#   define NV_PGRAPH_CONTROL_1_STENCIL_MASK_WRITE               0xFF000000
+#define NV_PGRAPH_CONTROL_2                              0x00001954
+#   define NV_PGRAPH_CONTROL_2_STENCIL_OP_FAIL                  0x0000000F
+#   define NV_PGRAPH_CONTROL_2_STENCIL_OP_ZFAIL                 0x000000F0
+#   define NV_PGRAPH_CONTROL_2_STENCIL_OP_ZPASS                 0x00000F00
+#       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_KEEP                1
+#       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_ZERO                2
+#       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_REPLACE             3
+#       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_INCRSAT             4
+#       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_DECRSAT             5
+#       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_INVERT              6
+#       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_INCR                7
+#       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_DECR                8
+#define NV_PGRAPH_CONTROL_3                              0x00001958
+#   define NV_PGRAPH_CONTROL_3_FOGENABLE                        (1 << 8)
+#   define NV_PGRAPH_CONTROL_3_FOG_MODE                         0x00070000
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_LINEAR                  0
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_EXP                     1
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_EXP2                    3
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_EXP_ABS                 5
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_EXP2_ABS                7
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_LINEAR_ABS              4
+#define NV_PGRAPH_FOGCOLOR                               0x00001980
+#   define NV_PGRAPH_FOGCOLOR_RED                               0x00FF0000
+#   define NV_PGRAPH_FOGCOLOR_GREEN                             0x0000FF00
+#   define NV_PGRAPH_FOGCOLOR_BLUE                              0x000000FF
+#   define NV_PGRAPH_FOGCOLOR_ALPHA                             0xFF000000
+#define NV_PGRAPH_FOGPARAM0                              0x00001984
+#define NV_PGRAPH_FOGPARAM1                              0x00001988
+#define NV_PGRAPH_SETUPRASTER                            0x00001990
+#   define NV_PGRAPH_SETUPRASTER_FRONTFACEMODE                  0x00000003
+#       define NV_PGRAPH_SETUPRASTER_FRONTFACEMODE_FILL             0
+#       define NV_PGRAPH_SETUPRASTER_FRONTFACEMODE_POINT            1
+#       define NV_PGRAPH_SETUPRASTER_FRONTFACEMODE_LINE             2
+#   define NV_PGRAPH_SETUPRASTER_BACKFACEMODE                   0x0000000C
+#   define NV_PGRAPH_SETUPRASTER_POFFSETPOINTENABLE             (1 << 6)
+#   define NV_PGRAPH_SETUPRASTER_POFFSETLINEENABLE              (1 << 7)
+#   define NV_PGRAPH_SETUPRASTER_POFFSETFILLENABLE              (1 << 8)
+#   define NV_PGRAPH_SETUPRASTER_CULLCTRL                       0x00600000
+#       define NV_PGRAPH_SETUPRASTER_CULLCTRL_FRONT                 1
+#       define NV_PGRAPH_SETUPRASTER_CULLCTRL_BACK                  2
+#       define NV_PGRAPH_SETUPRASTER_CULLCTRL_FRONT_AND_BACK        3
+#   define NV_PGRAPH_SETUPRASTER_FRONTFACE                      (1 << 23)
+#   define NV_PGRAPH_SETUPRASTER_CULLENABLE                     (1 << 28)
+#   define NV_PGRAPH_SETUPRASTER_Z_FORMAT                       (1 << 29)
+#   define NV_PGRAPH_SETUPRASTER_WINDOWCLIPTYPE                 (1 << 31)
+#define NV_PGRAPH_SHADERCLIPMODE                         0x00001994
+#define NV_PGRAPH_SHADERCTL                              0x00001998
+#define NV_PGRAPH_SHADERPROG                             0x0000199C
+#define NV_PGRAPH_SEMAPHOREOFFSET                        0x000019A0
+#define NV_PGRAPH_SHADOWZSLOPETHRESHOLD                  0x000019A8
+#define NV_PGRAPH_SPECFOGFACTOR0                         0x000019AC
+#define NV_PGRAPH_SPECFOGFACTOR1                         0x000019B0
+#define NV_PGRAPH_TEXADDRESS0                            0x000019BC
+#   define NV_PGRAPH_TEXADDRESS0_ADDRU                          0x00000007
+#       define NV_PGRAPH_TEXADDRESS0_ADDRU_WRAP                      1
+#       define NV_PGRAPH_TEXADDRESS0_ADDRU_MIRROR                    2
+#       define NV_PGRAPH_TEXADDRESS0_ADDRU_CLAMP_TO_EDGE             3
+#       define NV_PGRAPH_TEXADDRESS0_ADDRU_BORDER                    4
+#       define NV_PGRAPH_TEXADDRESS0_ADDRU_CLAMP_OGL                 5
+#   define NV_PGRAPH_TEXADDRESS0_WRAP_U                         (1 << 4)
+#   define NV_PGRAPH_TEXADDRESS0_ADDRV                          0x00000700
+#   define NV_PGRAPH_TEXADDRESS0_WRAP_V                         (1 << 12)
+#   define NV_PGRAPH_TEXADDRESS0_ADDRP                          0x00070000
+#   define NV_PGRAPH_TEXADDRESS0_WRAP_P                         (1 << 20)
+#   define NV_PGRAPH_TEXADDRESS0_WRAP_Q                         (1 << 24)
+#define NV_PGRAPH_TEXADDRESS1                            0x000019C0
+#define NV_PGRAPH_TEXADDRESS2                            0x000019C4
+#define NV_PGRAPH_TEXADDRESS3                            0x000019C8
+#define NV_PGRAPH_TEXCTL0_0                              0x000019CC
+#   define NV_PGRAPH_TEXCTL0_0_ALPHAKILLEN                      (1 << 2)
+#   define NV_PGRAPH_TEXCTL0_0_MAX_LOD_CLAMP                    0x0003FFC0
+#   define NV_PGRAPH_TEXCTL0_0_MIN_LOD_CLAMP                    0x3FFC0000
+#   define NV_PGRAPH_TEXCTL0_0_ENABLE                           (1 << 30)
+#define NV_PGRAPH_TEXCTL0_1                              0x000019D0
+#define NV_PGRAPH_TEXCTL0_2                              0x000019D4
+#define NV_PGRAPH_TEXCTL0_3                              0x000019D8
+#define NV_PGRAPH_TEXCTL1_0                              0x000019DC
+#   define NV_PGRAPH_TEXCTL1_0_IMAGE_PITCH                      0xFFFF0000
+#define NV_PGRAPH_TEXCTL1_1                              0x000019E0
+#define NV_PGRAPH_TEXCTL1_2                              0x000019E4
+#define NV_PGRAPH_TEXCTL1_3                              0x000019E8
+#define NV_PGRAPH_TEXCTL2_0                              0x000019EC
+#define NV_PGRAPH_TEXCTL2_1                              0x000019F0
+#define NV_PGRAPH_TEXFILTER0                             0x000019F4
+#   define NV_PGRAPH_TEXFILTER0_MIPMAP_LOD_BIAS                 0x00001FFF
+#   define NV_PGRAPH_TEXFILTER0_MIN                             0x003F0000
+#       define NV_PGRAPH_TEXFILTER0_MIN_BOX_LOD0                    1
+#       define NV_PGRAPH_TEXFILTER0_MIN_TENT_LOD0                   2
+#       define NV_PGRAPH_TEXFILTER0_MIN_BOX_NEARESTLOD              3
+#       define NV_PGRAPH_TEXFILTER0_MIN_TENT_NEARESTLOD             4
+#       define NV_PGRAPH_TEXFILTER0_MIN_BOX_TENT_LOD                5
+#       define NV_PGRAPH_TEXFILTER0_MIN_TENT_TENT_LOD               6
+#       define NV_PGRAPH_TEXFILTER0_MIN_CONVOLUTION_2D_LOD0         7
+#   define NV_PGRAPH_TEXFILTER0_MAG                             0x0F000000
+#   define NV_PGRAPH_TEXFILTER0_ASIGNED                         (1 << 28)
+#   define NV_PGRAPH_TEXFILTER0_RSIGNED                         (1 << 29)
+#   define NV_PGRAPH_TEXFILTER0_GSIGNED                         (1 << 30)
+#   define NV_PGRAPH_TEXFILTER0_BSIGNED                         (1 << 31)
+#define NV_PGRAPH_TEXFILTER1                             0x000019F8
+#define NV_PGRAPH_TEXFILTER2                             0x000019FC
+#define NV_PGRAPH_TEXFILTER3                             0x00001A00
+#define NV_PGRAPH_TEXFMT0                                0x00001A04
+#   define NV_PGRAPH_TEXFMT0_CONTEXT_DMA                        (1 << 1)
+#   define NV_PGRAPH_TEXFMT0_CUBEMAPENABLE                      (1 << 2)
+#   define NV_PGRAPH_TEXFMT0_BORDER_SOURCE                      (1 << 3)
+#       define NV_PGRAPH_TEXFMT0_BORDER_SOURCE_TEXTURE              0
+#       define NV_PGRAPH_TEXFMT0_BORDER_SOURCE_COLOR                1
+#   define NV_PGRAPH_TEXFMT0_DIMENSIONALITY                     0x000000C0
+#   define NV_PGRAPH_TEXFMT0_COLOR                              0x00007F00
+#   define NV_PGRAPH_TEXFMT0_MIPMAP_LEVELS                      0x000F0000
+#   define NV_PGRAPH_TEXFMT0_BASE_SIZE_U                        0x00F00000
+#   define NV_PGRAPH_TEXFMT0_BASE_SIZE_V                        0x0F000000
+#   define NV_PGRAPH_TEXFMT0_BASE_SIZE_P                        0xF0000000
+#define NV_PGRAPH_TEXFMT1                                0x00001A08
+#define NV_PGRAPH_TEXFMT2                                0x00001A0C
+#define NV_PGRAPH_TEXFMT3                                0x00001A10
+#define NV_PGRAPH_TEXIMAGERECT0                          0x00001A14
+#   define NV_PGRAPH_TEXIMAGERECT0_WIDTH                        0x1FFF0000
+#   define NV_PGRAPH_TEXIMAGERECT0_HEIGHT                       0x00001FFF
+#define NV_PGRAPH_TEXIMAGERECT1                          0x00001A18
+#define NV_PGRAPH_TEXIMAGERECT2                          0x00001A1C
+#define NV_PGRAPH_TEXIMAGERECT3                          0x00001A20
+#define NV_PGRAPH_TEXOFFSET0                             0x00001A24
+#define NV_PGRAPH_TEXOFFSET1                             0x00001A28
+#define NV_PGRAPH_TEXOFFSET2                             0x00001A2C
+#define NV_PGRAPH_TEXOFFSET3                             0x00001A30
+#define NV_PGRAPH_TEXPALETTE0                            0x00001A34
+#   define NV_PGRAPH_TEXPALETTE0_CONTEXT_DMA                    (1 << 0)
+#   define NV_PGRAPH_TEXPALETTE0_LENGTH                         0x0000000C
+#       define NV_PGRAPH_TEXPALETTE0_LENGTH_256                     0
+#       define NV_PGRAPH_TEXPALETTE0_LENGTH_128                     1
+#       define NV_PGRAPH_TEXPALETTE0_LENGTH_64                      2
+#       define NV_PGRAPH_TEXPALETTE0_LENGTH_32                      3
+#   define NV_PGRAPH_TEXPALETTE0_OFFSET                         0xFFFFFFC0
+#define NV_PGRAPH_TEXPALETTE1                            0x00001A38
+#define NV_PGRAPH_TEXPALETTE2                            0x00001A3C
+#define NV_PGRAPH_TEXPALETTE3                            0x00001A40
+#define NV_PGRAPH_WINDOWCLIPX0                           0x00001A44
+#   define NV_PGRAPH_WINDOWCLIPX0_XMIN                          0x00000FFF
+#   define NV_PGRAPH_WINDOWCLIPX0_XMAX                          0x0FFF0000
+#define NV_PGRAPH_WINDOWCLIPX1                           0x00001A48
+#define NV_PGRAPH_WINDOWCLIPX2                           0x00001A4C
+#define NV_PGRAPH_WINDOWCLIPX3                           0x00001A50
+#define NV_PGRAPH_WINDOWCLIPX4                           0x00001A54
+#define NV_PGRAPH_WINDOWCLIPX5                           0x00001A58
+#define NV_PGRAPH_WINDOWCLIPX6                           0x00001A5C
+#define NV_PGRAPH_WINDOWCLIPX7                           0x00001A60
+#define NV_PGRAPH_WINDOWCLIPY0                           0x00001A64
+#   define NV_PGRAPH_WINDOWCLIPY0_YMIN                          0x00000FFF
+#   define NV_PGRAPH_WINDOWCLIPY0_YMAX                          0x0FFF0000
+#define NV_PGRAPH_WINDOWCLIPY1                           0x00001A68
+#define NV_PGRAPH_WINDOWCLIPY2                           0x00001A6C
+#define NV_PGRAPH_WINDOWCLIPY3                           0x00001A70
+#define NV_PGRAPH_WINDOWCLIPY4                           0x00001A74
+#define NV_PGRAPH_WINDOWCLIPY5                           0x00001A78
+#define NV_PGRAPH_WINDOWCLIPY6                           0x00001A7C
+#define NV_PGRAPH_WINDOWCLIPY7                           0x00001A80
+#define NV_PGRAPH_ZSTENCILCLEARVALUE                     0x00001A88
+#define NV_PGRAPH_ZCLIPMIN                               0x00001A90
+#define NV_PGRAPH_ZOFFSETBIAS                            0x00001AA4
+#define NV_PGRAPH_ZOFFSETFACTOR                          0x00001AA8
+#define NV_PGRAPH_EYEVEC0                                0x00001AAC
+#define NV_PGRAPH_EYEVEC1                                0x00001AB0
+#define NV_PGRAPH_EYEVEC2                                0x00001AB4
+#define NV_PGRAPH_ZCLIPMAX                               0x00001ABC
+
+
+#define NV_PCRTC_INTR_0                                  0x00000100
+#   define NV_PCRTC_INTR_0_VBLANK                               (1 << 0)
+#define NV_PCRTC_INTR_EN_0                               0x00000140
+#   define NV_PCRTC_INTR_EN_0_VBLANK                            (1 << 0)
+#define NV_PCRTC_START                                   0x00000800
+#define NV_PCRTC_CONFIG                                  0x00000804
+
+
+#define NV_PVIDEO_INTR                                   0x00000100
+#   define NV_PVIDEO_INTR_BUFFER_0                              (1 << 0)
+#   define NV_PVIDEO_INTR_BUFFER_1                              (1 << 4)
+#define NV_PVIDEO_INTR_EN                                0x00000140
+#   define NV_PVIDEO_INTR_EN_BUFFER_0                           (1 << 0)
+#   define NV_PVIDEO_INTR_EN_BUFFER_1                           (1 << 4)
+#define NV_PVIDEO_BUFFER                                 0x00000700
+#   define NV_PVIDEO_BUFFER_0_USE                               (1 << 0)
+#   define NV_PVIDEO_BUFFER_1_USE                               (1 << 4)
+#define NV_PVIDEO_STOP                                   0x00000704
+#define NV_PVIDEO_BASE                                   0x00000900
+#define NV_PVIDEO_LIMIT                                  0x00000908
+#define NV_PVIDEO_LUMINANCE                              0x00000910
+#define NV_PVIDEO_CHROMINANCE                            0x00000918
+#define NV_PVIDEO_OFFSET                                 0x00000920
+#define NV_PVIDEO_SIZE_IN                                0x00000928
+#   define NV_PVIDEO_SIZE_IN_WIDTH                            0x000007FF
+#   define NV_PVIDEO_SIZE_IN_HEIGHT                           0x07FF0000
+#define NV_PVIDEO_POINT_IN                               0x00000930
+#   define NV_PVIDEO_POINT_IN_S                               0x00007FFF
+#   define NV_PVIDEO_POINT_IN_T                               0xFFFE0000
+#define NV_PVIDEO_DS_DX                                  0x00000938
+#define NV_PVIDEO_DT_DY                                  0x00000940
+#define NV_PVIDEO_POINT_OUT                              0x00000948
+#   define NV_PVIDEO_POINT_OUT_X                              0x00000FFF
+#   define NV_PVIDEO_POINT_OUT_Y                              0x0FFF0000
+#define NV_PVIDEO_SIZE_OUT                               0x00000950
+#   define NV_PVIDEO_SIZE_OUT_WIDTH                           0x00000FFF
+#   define NV_PVIDEO_SIZE_OUT_HEIGHT                          0x0FFF0000
+#define NV_PVIDEO_FORMAT                                 0x00000958
+#   define NV_PVIDEO_FORMAT_PITCH                             0x00001FFF
+#   define NV_PVIDEO_FORMAT_COLOR                             0x00030000
+#       define NV_PVIDEO_FORMAT_COLOR_LE_CR8YB8CB8YA8             1
+#   define NV_PVIDEO_FORMAT_DISPLAY                            (1 << 20)
+
+
+#define NV_PTIMER_INTR_0                                 0x00000100
+#   define NV_PTIMER_INTR_0_ALARM                               (1 << 0)
+#define NV_PTIMER_INTR_EN_0                              0x00000140
+#   define NV_PTIMER_INTR_EN_0_ALARM                            (1 << 0)
+#define NV_PTIMER_NUMERATOR                              0x00000200
+#define NV_PTIMER_DENOMINATOR                            0x00000210
+#define NV_PTIMER_TIME_0                                 0x00000400
+#define NV_PTIMER_TIME_1                                 0x00000410
+#define NV_PTIMER_ALARM_0                                0x00000420
+
+
+#define NV_PFB_CFG0                                      0x00000200
+#   define NV_PFB_CFG0_PART                                   0x00000003
+#define NV_PFB_CSTATUS                                   0x0000020C
+#define NV_PFB_WBC                                       0x00000410
+#   define NV_PFB_WBC_FLUSH                                     (1 << 16)
+
+
+#define NV_PRAMDAC_NVPLL_COEFF                           0x00000500
+#   define NV_PRAMDAC_NVPLL_COEFF_MDIV                        0x000000FF
+#   define NV_PRAMDAC_NVPLL_COEFF_NDIV                        0x0000FF00
+#   define NV_PRAMDAC_NVPLL_COEFF_PDIV                        0x00070000
+#define NV_PRAMDAC_MPLL_COEFF                            0x00000504
+#   define NV_PRAMDAC_MPLL_COEFF_MDIV                         0x000000FF
+#   define NV_PRAMDAC_MPLL_COEFF_NDIV                         0x0000FF00
+#   define NV_PRAMDAC_MPLL_COEFF_PDIV                         0x00070000
+#define NV_PRAMDAC_VPLL_COEFF                            0x00000508
+#   define NV_PRAMDAC_VPLL_COEFF_MDIV                         0x000000FF
+#   define NV_PRAMDAC_VPLL_COEFF_NDIV                         0x0000FF00
+#   define NV_PRAMDAC_VPLL_COEFF_PDIV                         0x00070000
+#define NV_PRAMDAC_PLL_TEST_COUNTER                      0x00000514
+#   define NV_PRAMDAC_PLL_TEST_COUNTER_NOOFIPCLKS             0x000003FF
+#   define NV_PRAMDAC_PLL_TEST_COUNTER_VALUE                  0x0000FFFF
+#   define NV_PRAMDAC_PLL_TEST_COUNTER_ENABLE                  (1 << 16)
+#   define NV_PRAMDAC_PLL_TEST_COUNTER_RESET                   (1 << 20)
+#   define NV_PRAMDAC_PLL_TEST_COUNTER_SOURCE                 0x03000000
+#   define NV_PRAMDAC_PLL_TEST_COUNTER_VPLL2_LOCK              (1 << 27)
+#   define NV_PRAMDAC_PLL_TEST_COUNTER_PDIV_RST                (1 << 28)
+#   define NV_PRAMDAC_PLL_TEST_COUNTER_NVPLL_LOCK              (1 << 29)
+#   define NV_PRAMDAC_PLL_TEST_COUNTER_MPLL_LOCK               (1 << 30)
+#   define NV_PRAMDAC_PLL_TEST_COUNTER_VPLL_LOCK               (1 << 31)
+#define NV_PRAMDAC_GENERAL_CONTROL                       0x00000600
+#   define NV_PRAMDAC_GENERAL_CONTROL_ALT_MODE                 (1 << 12)
+
+#define NV_USER_DMA_PUT                                  0x40
+#define NV_USER_DMA_GET                                  0x44
+#define NV_USER_REF                                      0x48
+
+
+
+/* DMA objects */
+#define NV_DMA_FROM_MEMORY_CLASS                         0x02
+#define NV_DMA_TO_MEMORY_CLASS                           0x03
+#define NV_DMA_IN_MEMORY_CLASS                           0x3d
+
+#define NV_DMA_CLASS                                          0x00000FFF
+#define NV_DMA_PAGE_TABLE                                      (1 << 12)
+#define NV_DMA_PAGE_ENTRY                                      (1 << 13)
+#define NV_DMA_FLAGS_ACCESS                                    (1 << 14)
+#define NV_DMA_FLAGS_MAPPING_COHERENCY                         (1 << 15)
+#define NV_DMA_TARGET                                         0x00030000
+#   define NV_DMA_TARGET_NVM                                      0x00000000
+#   define NV_DMA_TARGET_NVM_TILED                                0x00010000
+#   define NV_DMA_TARGET_PCI                                      0x00020000
+#   define NV_DMA_TARGET_AGP                                      0x00030000
+#define NV_DMA_ADJUST                                         0xFFF00000
+
+#define NV_DMA_ADDRESS                                        0xFFFFF000
+
+
+#define NV_RAMHT_HANDLE                                       0xFFFFFFFF
+#define NV_RAMHT_INSTANCE                                     0x0000FFFF
+#define NV_RAMHT_ENGINE                                       0x00030000
+#   define NV_RAMHT_ENGINE_SW                                     0x00000000
+#   define NV_RAMHT_ENGINE_GRAPHICS                               0x00010000
+#   define NV_RAMHT_ENGINE_DVD                                    0x00020000
+#define NV_RAMHT_CHID                                         0x1F000000
+#define NV_RAMHT_STATUS                                       0x80000000
+
+
+
+/* graphic classes and methods */
+#define NV_SET_OBJECT                                        0x00000000
+
+#define NV_MEMORY_TO_MEMORY_FORMAT                       0x0039
+
+#define NV_CONTEXT_PATTERN                               0x0044
+#   define NV044_SET_MONOCHROME_COLOR0                        0x00000310
+
+#define NV_CONTEXT_SURFACES_2D                           0x0062
+#   define NV062_SET_OBJECT                                   0x00000000
+#   define NV062_SET_CONTEXT_DMA_IMAGE_SOURCE                 0x00000184
+#   define NV062_SET_CONTEXT_DMA_IMAGE_DESTIN                 0x00000188
+#   define NV062_SET_COLOR_FORMAT                             0x00000300
+#       define NV062_SET_COLOR_FORMAT_LE_Y8                    0x01
+#       define NV062_SET_COLOR_FORMAT_LE_R5G6B5                0x04
+#       define NV062_SET_COLOR_FORMAT_LE_A8R8G8B8              0x0A
+#   define NV062_SET_PITCH                                    0x00000304
+#   define NV062_SET_OFFSET_SOURCE                            0x00000308
+#   define NV062_SET_OFFSET_DESTIN                            0x0000030C
+
+#define NV_IMAGE_BLIT                                    0x009F
+#   define NV09F_SET_OBJECT                                   0x00000000
+#   define NV09F_SET_CONTEXT_SURFACES                         0x0000019C
+#   define NV09F_SET_OPERATION                                0x000002FC
+#       define NV09F_SET_OPERATION_SRCCOPY                        3
+#   define NV09F_CONTROL_POINT_IN                             0x00000300
+#   define NV09F_CONTROL_POINT_OUT                            0x00000304
+#   define NV09F_SIZE                                         0x00000308
+
+
+#define NV_KELVIN_PRIMITIVE                              0x0097
+#   define NV097_SET_OBJECT                                   0x00000000
+#   define NV097_NO_OPERATION                                 0x00000100
+#   define NV097_WAIT_FOR_IDLE                                0x00000110
+#   define NV097_SET_FLIP_READ                                0x00000120
+#   define NV097_SET_FLIP_WRITE                               0x00000124
+#   define NV097_SET_FLIP_MODULO                              0x00000128
+#   define NV097_FLIP_INCREMENT_WRITE                         0x0000012C
+#   define NV097_FLIP_STALL                                   0x00000130
+#   define NV097_SET_CONTEXT_DMA_NOTIFIES                     0x00000180
+#   define NV097_SET_CONTEXT_DMA_A                            0x00000184
+#   define NV097_SET_CONTEXT_DMA_B                            0x00000188
+#   define NV097_SET_CONTEXT_DMA_STATE                        0x00000190
+#   define NV097_SET_CONTEXT_DMA_COLOR                        0x00000194
+#   define NV097_SET_CONTEXT_DMA_ZETA                         0x00000198
+#   define NV097_SET_CONTEXT_DMA_VERTEX_A                     0x0000019C
+#   define NV097_SET_CONTEXT_DMA_VERTEX_B                     0x000001A0
+#   define NV097_SET_CONTEXT_DMA_SEMAPHORE                    0x000001A4
+#   define NV097_SET_CONTEXT_DMA_REPORT                       0x000001A8
+#   define NV097_SET_SURFACE_CLIP_HORIZONTAL                  0x00000200
+#       define NV097_SET_SURFACE_CLIP_HORIZONTAL_X                0x0000FFFF
+#       define NV097_SET_SURFACE_CLIP_HORIZONTAL_WIDTH            0xFFFF0000
+#   define NV097_SET_SURFACE_CLIP_VERTICAL                    0x00000204
+#       define NV097_SET_SURFACE_CLIP_VERTICAL_Y                  0x0000FFFF
+#       define NV097_SET_SURFACE_CLIP_VERTICAL_HEIGHT             0xFFFF0000
+#   define NV097_SET_SURFACE_FORMAT                           0x00000208
+#       define NV097_SET_SURFACE_FORMAT_COLOR                     0x0000000F
+#           define NV097_SET_SURFACE_FORMAT_COLOR_LE_X1R5G5B5_Z1R5G5B5     0x01
+#           define NV097_SET_SURFACE_FORMAT_COLOR_LE_X1R5G5B5_O1R5G5B5     0x02
+#           define NV097_SET_SURFACE_FORMAT_COLOR_LE_R5G6B5                0x03
+#           define NV097_SET_SURFACE_FORMAT_COLOR_LE_X8R8G8B8_Z8R8G8B8     0x04
+#           define NV097_SET_SURFACE_FORMAT_COLOR_LE_X8R8G8B8_O8R8G8B8     0x05
+#           define NV097_SET_SURFACE_FORMAT_COLOR_LE_X1A7R8G8B8_Z1A7R8G8B8 0x06
+#           define NV097_SET_SURFACE_FORMAT_COLOR_LE_X1A7R8G8B8_O1A7R8G8B8 0x07
+#           define NV097_SET_SURFACE_FORMAT_COLOR_LE_A8R8G8B8              0x08
+#           define NV097_SET_SURFACE_FORMAT_COLOR_LE_B8                    0x09
+#           define NV097_SET_SURFACE_FORMAT_COLOR_LE_G8B8                  0x0A
+#       define NV097_SET_SURFACE_FORMAT_ZETA                      0x000000F0
+#           define NV097_SET_SURFACE_FORMAT_ZETA_Z16                       1
+#           define NV097_SET_SURFACE_FORMAT_ZETA_Z24S8                     2
+#       define NV097_SET_SURFACE_FORMAT_TYPE                      0x00000F00
+#           define NV097_SET_SURFACE_FORMAT_TYPE_PITCH                     0x1
+#           define NV097_SET_SURFACE_FORMAT_TYPE_SWIZZLE                   0x2
+#       define NV097_SET_SURFACE_FORMAT_ANTI_ALIASING             0x0000F000
+#           define NV097_SET_SURFACE_FORMAT_ANTI_ALIASING_CENTER_1         0
+#           define NV097_SET_SURFACE_FORMAT_ANTI_ALIASING_CENTER_CORNER_2  1
+#           define NV097_SET_SURFACE_FORMAT_ANTI_ALIASING_SQUARE_OFFSET_4  2
+#       define NV097_SET_SURFACE_FORMAT_WIDTH                     0x00FF0000
+#       define NV097_SET_SURFACE_FORMAT_HEIGHT                    0xFF000000
+#   define NV097_SET_SURFACE_PITCH                            0x0000020C
+#       define NV097_SET_SURFACE_PITCH_COLOR                      0x0000FFFF
+#       define NV097_SET_SURFACE_PITCH_ZETA                       0xFFFF0000
+#   define NV097_SET_SURFACE_COLOR_OFFSET                     0x00000210
+#   define NV097_SET_SURFACE_ZETA_OFFSET                      0x00000214
+#   define NV097_SET_COMBINER_ALPHA_ICW                       0x00000260
+#   define NV097_SET_COMBINER_SPECULAR_FOG_CW0                0x00000288
+#   define NV097_SET_COMBINER_SPECULAR_FOG_CW1                0x0000028C
+#   define NV097_SET_CONTROL0                                 0x00000290
+#       define NV097_SET_CONTROL0_STENCIL_WRITE_ENABLE            (1 << 0)
+#       define NV097_SET_CONTROL0_Z_FORMAT                        (1 << 12)
+#       define NV097_SET_CONTROL0_Z_PERSPECTIVE_ENABLE            (1 << 16)
+#   define NV097_SET_FOG_MODE                                 0x0000029C
+#       define NV097_SET_FOG_MODE_V_LINEAR                        0x2601
+#       define NV097_SET_FOG_MODE_V_EXP                           0x800
+#       define NV097_SET_FOG_MODE_V_EXP2                          0x801
+#       define NV097_SET_FOG_MODE_V_EXP_ABS                       0x802
+#       define NV097_SET_FOG_MODE_V_EXP2_ABS                      0x803
+#       define NV097_SET_FOG_MODE_V_LINEAR_ABS                    0x804
+#   define NV097_SET_FOG_GEN_MODE                             0x000002A0
+#       define NV097_SET_FOG_GEN_MODE_V_SPEC_ALPHA                0
+#       define NV097_SET_FOG_GEN_MODE_V_RADIAL                    1
+#       define NV097_SET_FOG_GEN_MODE_V_PLANAR                    2
+#       define NV097_SET_FOG_GEN_MODE_V_ABS_PLANAR                3
+#       define NV097_SET_FOG_GEN_MODE_V_FOG_X                     6
+#   define NV097_SET_FOG_ENABLE                               0x000002A4
+#   define NV097_SET_FOG_COLOR                                0x000002A8
+#       define NV097_SET_FOG_COLOR_RED                            0x000000FF
+#       define NV097_SET_FOG_COLOR_GREEN                          0x0000FF00
+#       define NV097_SET_FOG_COLOR_BLUE                           0x00FF0000
+#       define NV097_SET_FOG_COLOR_ALPHA                          0xFF000000
+#   define NV097_SET_WINDOW_CLIP_TYPE                         0x000002B4
+#   define NV097_SET_WINDOW_CLIP_HORIZONTAL                   0x000002C0
+#       define NV097_SET_WINDOW_CLIP_HORIZONTAL_XMIN              0x00000FFF
+#       define NV097_SET_WINDOW_CLIP_HORIZONTAL_XMAX              0x0FFF0000
+#   define NV097_SET_WINDOW_CLIP_VERTICAL                     0x000002E0
+#   define NV097_SET_ALPHA_TEST_ENABLE                        0x00000300
+#   define NV097_SET_BLEND_ENABLE                             0x00000304
+#   define NV097_SET_CULL_FACE_ENABLE                         0x00000308
+#   define NV097_SET_DEPTH_TEST_ENABLE                        0x0000030C
+#   define NV097_SET_DITHER_ENABLE                            0x00000310
+#   define NV097_SET_LIGHTING_ENABLE                          0x00000314
+#   define NV097_SET_SKIN_MODE                                0x00000328
+#       define NV097_SET_SKIN_MODE_OFF                            0
+#       define NV097_SET_SKIN_MODE_2G                             1
+#       define NV097_SET_SKIN_MODE_2                              2
+#       define NV097_SET_SKIN_MODE_3G                             3
+#       define NV097_SET_SKIN_MODE_3                              4
+#       define NV097_SET_SKIN_MODE_4G                             5
+#       define NV097_SET_SKIN_MODE_4                              6
+#   define NV097_SET_STENCIL_TEST_ENABLE                      0x0000032C
+#   define NV097_SET_POLY_OFFSET_POINT_ENABLE                 0x00000330
+#   define NV097_SET_POLY_OFFSET_LINE_ENABLE                  0x00000334
+#   define NV097_SET_POLY_OFFSET_FILL_ENABLE                  0x00000338
+#   define NV097_SET_ALPHA_FUNC                               0x0000033C
+#   define NV097_SET_ALPHA_REF                                0x00000340
+#   define NV097_SET_BLEND_FUNC_SFACTOR                       0x00000344
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_ZERO                0x0000
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_ONE                 0x0001
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_SRC_COLOR           0x0300
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_SRC_COLOR 0x0301
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_SRC_ALPHA           0x0302
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_SRC_ALPHA 0x0303
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_DST_ALPHA           0x0304
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_DST_ALPHA 0x0305
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_DST_COLOR           0x0306
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_DST_COLOR 0x0307
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_SRC_ALPHA_SATURATE  0x0308
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_CONSTANT_COLOR      0x8001
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_CONSTANT_COLOR 0x8002
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_CONSTANT_ALPHA      0x8003
+#       define NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_CONSTANT_ALPHA 0x8004
+#   define NV097_SET_BLEND_FUNC_DFACTOR                       0x00000348
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_ZERO                0x0000
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_ONE                 0x0001
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_SRC_COLOR           0x0300
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_ONE_MINUS_SRC_COLOR 0x0301
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_SRC_ALPHA           0x0302
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_ONE_MINUS_SRC_ALPHA 0x0303
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_DST_ALPHA           0x0304
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_ONE_MINUS_DST_ALPHA 0x0305
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_DST_COLOR           0x0306
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_ONE_MINUS_DST_COLOR 0x0307
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_SRC_ALPHA_SATURATE  0x0308
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_CONSTANT_COLOR      0x8001
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_ONE_MINUS_CONSTANT_COLOR 0x8002
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_CONSTANT_ALPHA      0x8003
+#       define NV097_SET_BLEND_FUNC_DFACTOR_V_ONE_MINUS_CONSTANT_ALPHA 0x8004
+#   define NV097_SET_BLEND_COLOR                              0x0000034C
+#   define NV097_SET_BLEND_EQUATION                           0x00000350
+#       define NV097_SET_BLEND_EQUATION_V_FUNC_SUBTRACT           0x800A
+#       define NV097_SET_BLEND_EQUATION_V_FUNC_REVERSE_SUBTRACT   0x800B
+#       define NV097_SET_BLEND_EQUATION_V_FUNC_ADD                0x8006
+#       define NV097_SET_BLEND_EQUATION_V_MIN                     0x8007
+#       define NV097_SET_BLEND_EQUATION_V_MAX                     0x8008
+#       define NV097_SET_BLEND_EQUATION_V_FUNC_REVERSE_SUBTRACT_SIGNED 0xF005
+#       define NV097_SET_BLEND_EQUATION_V_FUNC_ADD_SIGNED         0xF006
+#   define NV097_SET_DEPTH_FUNC                               0x00000354
+#   define NV097_SET_COLOR_MASK                               0x00000358
+#       define NV097_SET_COLOR_MASK_BLUE_WRITE_ENABLE             (1 << 0)
+#       define NV097_SET_COLOR_MASK_GREEN_WRITE_ENABLE            (1 << 8)
+#       define NV097_SET_COLOR_MASK_RED_WRITE_ENABLE              (1 << 16)
+#       define NV097_SET_COLOR_MASK_ALPHA_WRITE_ENABLE            (1 << 24)
+#   define NV097_SET_DEPTH_MASK                               0x0000035C
+#   define NV097_SET_STENCIL_MASK                             0x00000360
+#   define NV097_SET_STENCIL_FUNC                             0x00000364
+#   define NV097_SET_STENCIL_FUNC_REF                         0x00000368
+#   define NV097_SET_STENCIL_FUNC_MASK                        0x0000036C
+#   define NV097_SET_STENCIL_OP_FAIL                          0x00000370
+#   define NV097_SET_STENCIL_OP_ZFAIL                         0x00000374
+#   define NV097_SET_STENCIL_OP_ZPASS                         0x00000378
+#       define NV097_SET_STENCIL_OP_V_KEEP                        0x1E00
+#       define NV097_SET_STENCIL_OP_V_ZERO                        0x0000
+#       define NV097_SET_STENCIL_OP_V_REPLACE                     0x1E01
+#       define NV097_SET_STENCIL_OP_V_INCRSAT                     0x1E02
+#       define NV097_SET_STENCIL_OP_V_DECRSAT                     0x1E03
+#       define NV097_SET_STENCIL_OP_V_INVERT                      0x150A
+#       define NV097_SET_STENCIL_OP_V_INCR                        0x8507
+#       define NV097_SET_STENCIL_OP_V_DECR                        0x8508
+#   define NV097_SET_POLYGON_OFFSET_SCALE_FACTOR              0x00000384
+#   define NV097_SET_POLYGON_OFFSET_BIAS                      0x00000388
+#   define NV097_SET_FRONT_POLYGON_MODE                       0x0000038C
+#       define NV097_SET_FRONT_POLYGON_MODE_V_POINT               0x1B00
+#       define NV097_SET_FRONT_POLYGON_MODE_V_LINE                0x1B01
+#       define NV097_SET_FRONT_POLYGON_MODE_V_FILL                0x1B02
+#   define NV097_SET_BACK_POLYGON_MODE                        0x00000390
+#   define NV097_SET_CLIP_MIN                                 0x00000394
+#   define NV097_SET_CLIP_MAX                                 0x00000398
+#   define NV097_SET_CULL_FACE                                0x0000039C
+#       define NV097_SET_CULL_FACE_V_FRONT                         0x404
+#       define NV097_SET_CULL_FACE_V_BACK                          0x405
+#       define NV097_SET_CULL_FACE_V_FRONT_AND_BACK                0x408
+#   define NV097_SET_FRONT_FACE                               0x000003A0
+#       define NV097_SET_FRONT_FACE_V_CW                           0x900
+#       define NV097_SET_FRONT_FACE_V_CCW                          0x901
+#   define NV097_SET_NORMALIZATION_ENABLE                     0x000003A4
+#   define NV097_SET_LIGHT_ENABLE_MASK                        0x000003BC
+#           define NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_OFF           0
+#           define NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_INFINITE      1
+#           define NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_LOCAL         2
+#           define NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_SPOT          3
+#   define NV097_SET_TEXGEN_S                                 0x000003C0
+#       define NV097_SET_TEXGEN_S_DISABLE                         0x0000
+#       define NV097_SET_TEXGEN_S_EYE_LINEAR                      0x2400
+#       define NV097_SET_TEXGEN_S_OBJECT_LINEAR                   0x2401
+#       define NV097_SET_TEXGEN_S_SPHERE_MAP                      0x2402
+#       define NV097_SET_TEXGEN_S_REFLECTION_MAP                  0x8512
+#       define NV097_SET_TEXGEN_S_NORMAL_MAP                      0x8511
+#   define NV097_SET_TEXGEN_T                                 0x000003C4
+#   define NV097_SET_TEXGEN_R                                 0x000003C8
+#   define NV097_SET_TEXGEN_Q                                 0x000003CC
+#   define NV097_SET_TEXTURE_MATRIX_ENABLE                    0x00000420
+#   define NV097_SET_PROJECTION_MATRIX                        0x00000440
+#   define NV097_SET_MODEL_VIEW_MATRIX                        0x00000480
+#   define NV097_SET_INVERSE_MODEL_VIEW_MATRIX                0x00000580
+#   define NV097_SET_COMPOSITE_MATRIX                         0x00000680
+#   define NV097_SET_TEXTURE_MATRIX                           0x000006C0
+#   define NV097_SET_FOG_PARAMS                               0x000009C0
+#   define NV097_SET_TEXGEN_PLANE_S                           0x00000840
+#   define NV097_SET_TEXGEN_PLANE_T                           0x00000850
+#   define NV097_SET_TEXGEN_PLANE_R                           0x00000860
+#   define NV097_SET_TEXGEN_PLANE_Q                           0x00000870
+#   define NV097_SET_TEXGEN_VIEW_MODEL                        0x000009CC
+#       define NV097_SET_TEXGEN_VIEW_MODEL_LOCAL_VIEWER           0
+#       define NV097_SET_TEXGEN_VIEW_MODEL_INFINITE_VIEWER        1
+#   define NV097_SET_FOG_PLANE                                0x000009D0
+#   define NV097_SET_SCENE_AMBIENT_COLOR                      0x00000A10
+#   define NV097_SET_VIEWPORT_OFFSET                          0x00000A20
+#   define NV097_SET_EYE_POSITION                             0x00000A50
+#   define NV097_SET_COMBINER_FACTOR0                         0x00000A60
+#   define NV097_SET_COMBINER_FACTOR1                         0x00000A80
+#   define NV097_SET_COMBINER_ALPHA_OCW                       0x00000AA0
+#   define NV097_SET_COMBINER_COLOR_ICW                       0x00000AC0
+#   define NV097_SET_VIEWPORT_SCALE                           0x00000AF0
+#   define NV097_SET_TRANSFORM_PROGRAM                        0x00000B00
+#   define NV097_SET_TRANSFORM_CONSTANT                       0x00000B80
+#   define NV097_SET_VERTEX3F                                 0x00001500
+#   define NV097_SET_BACK_LIGHT_AMBIENT_COLOR                 0x00000C00
+#   define NV097_SET_BACK_LIGHT_DIFFUSE_COLOR                 0x00000C0C
+#   define NV097_SET_BACK_LIGHT_SPECULAR_COLOR                0x00000C18
+#   define NV097_SET_LIGHT_AMBIENT_COLOR                      0x00001000
+#   define NV097_SET_LIGHT_DIFFUSE_COLOR                      0x0000100C
+#   define NV097_SET_LIGHT_SPECULAR_COLOR                     0x00001018
+#   define NV097_SET_LIGHT_LOCAL_RANGE                        0x00001024
+#   define NV097_SET_LIGHT_INFINITE_HALF_VECTOR               0x00001028
+#   define NV097_SET_LIGHT_INFINITE_DIRECTION                 0x00001034
+#   define NV097_SET_LIGHT_SPOT_FALLOFF                       0x00001040
+#   define NV097_SET_LIGHT_SPOT_DIRECTION                     0x0000104C
+#   define NV097_SET_LIGHT_LOCAL_POSITION                     0x0000105C
+#   define NV097_SET_LIGHT_LOCAL_ATTENUATION                  0x00001068
+#   define NV097_SET_VERTEX4F                                 0x00001518
+#   define NV097_SET_VERTEX_DATA_ARRAY_OFFSET                 0x00001720
+#   define NV097_SET_VERTEX_DATA_ARRAY_FORMAT                 0x00001760
+#       define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE            0x0000000F
+#           define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_UB_D3D     0
+#           define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_S1         1
+#           define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F          2
+#           define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_UB_OGL     4
+#           define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_S32K       5
+#           define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_CMP        6
+#       define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_SIZE            0x000000F0
+#       define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_STRIDE          0xFFFFFF00
+#   define NV097_SET_LOGIC_OP_ENABLE                          0x000017BC
+#   define NV097_SET_LOGIC_OP                                 0x000017C0
+#   define NV097_CLEAR_REPORT_VALUE                           0x000017C8
+#       define NV097_CLEAR_REPORT_VALUE_TYPE                      0xFFFFFFFF
+#           define NV097_CLEAR_REPORT_VALUE_TYPE_ZPASS_PIXEL_CNT      1
+#   define NV097_SET_ZPASS_PIXEL_COUNT_ENABLE                 0x000017CC
+#   define NV097_GET_REPORT                                   0x000017D0
+#       define NV097_GET_REPORT_OFFSET                            0x00FFFFFF
+#       define NV097_GET_REPORT_TYPE                              0xFF000000
+#           define NV097_GET_REPORT_TYPE_ZPASS_PIXEL_CNT              1
+#   define NV097_SET_EYE_DIRECTION                            0x000017E0
+#   define NV097_SET_SHADER_CLIP_PLANE_MODE                   0x000017F8
+#   define NV097_SET_BEGIN_END                                0x000017FC
+#       define NV097_SET_BEGIN_END_OP_END                         0x00
+#       define NV097_SET_BEGIN_END_OP_POINTS                      0x01
+#       define NV097_SET_BEGIN_END_OP_LINES                       0x02
+#       define NV097_SET_BEGIN_END_OP_LINE_LOOP                   0x03
+#       define NV097_SET_BEGIN_END_OP_LINE_STRIP                  0x04
+#       define NV097_SET_BEGIN_END_OP_TRIANGLES                   0x05
+#       define NV097_SET_BEGIN_END_OP_TRIANGLE_STRIP              0x06
+#       define NV097_SET_BEGIN_END_OP_TRIANGLE_FAN                0x07
+#       define NV097_SET_BEGIN_END_OP_QUADS                       0x08
+#       define NV097_SET_BEGIN_END_OP_QUAD_STRIP                  0x09
+#       define NV097_SET_BEGIN_END_OP_POLYGON                     0x0A
+#   define NV097_ARRAY_ELEMENT16                              0x00001800
+#   define NV097_ARRAY_ELEMENT32                              0x00001808
+#   define NV097_DRAW_ARRAYS                                  0x00001810
+#       define NV097_DRAW_ARRAYS_COUNT                            0xFF000000
+#       define NV097_DRAW_ARRAYS_START_INDEX                      0x00FFFFFF
+#   define NV097_INLINE_ARRAY                                 0x00001818
+#   define NV097_SET_EYE_VECTOR                               0x0000181C
+#   define NV097_SET_VERTEX_DATA2F_M                          0x00001880
+#   define NV097_SET_VERTEX_DATA4F_M                          0x00001A00
+#   define NV097_SET_VERTEX_DATA2S                            0x00001900
+#   define NV097_SET_VERTEX_DATA4UB                           0x00001940
+#   define NV097_SET_VERTEX_DATA4S_M                          0x00001980
+#   define NV097_SET_TEXTURE_OFFSET                           0x00001B00
+#   define NV097_SET_TEXTURE_FORMAT                           0x00001B04
+#       define NV097_SET_TEXTURE_FORMAT_CONTEXT_DMA               0x00000003
+#       define NV097_SET_TEXTURE_FORMAT_CUBEMAP_ENABLE            (1 << 2)
+#       define NV097_SET_TEXTURE_FORMAT_BORDER_SOURCE             (1 << 3)
+#           define NV097_SET_TEXTURE_FORMAT_BORDER_SOURCE_TEXTURE   0
+#           define NV097_SET_TEXTURE_FORMAT_BORDER_SOURCE_COLOR     1
+#       define NV097_SET_TEXTURE_FORMAT_DIMENSIONALITY            0x000000F0
+#       define NV097_SET_TEXTURE_FORMAT_COLOR                     0x0000FF00
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_Y8             0x00
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_AY8            0x01
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_A1R5G5B5       0x02
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_X1R5G5B5       0x03
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_A4R4G4B4       0x04
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_R5G6B5         0x05
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_A8R8G8B8       0x06
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_X8R8G8B8       0x07
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_I8_A8R8G8B8    0x0B
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_L_DXT1_A1R5G5B5   0x0C
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_L_DXT23_A8R8G8B8  0x0E
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_L_DXT45_A8R8G8B8  0x0F
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_A1R5G5B5 0x10
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_R5G6B5   0x11
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_A8R8G8B8 0x12
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_Y8       0x13
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_A8             0x19
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_A8Y8           0x1A
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_AY8      0x1B
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_X1R5G5B5 0x1C
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_A4R4G4B4 0x1D
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_X8R8G8B8 0x1E
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_A8       0x1F
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_A8Y8     0x20
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LC_IMAGE_CR8YB8CB8YA8 0x24
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_R6G5B5         0x27
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_G8B8           0x28
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_R8B8           0x29
+# define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_DEPTH_X8_Y24_FIXED 0x2E
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_DEPTH_Y16_FIXED 0x30
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_Y16      0x35
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_A8B8G8R8       0x3A
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_SZ_R8G8B8A8       0x3C
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_A8B8G8R8 0x3F
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_B8G8R8A8 0x40
+#           define NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_R8G8B8A8 0x41
+#       define NV097_SET_TEXTURE_FORMAT_MIPMAP_LEVELS             0x000F0000
+#       define NV097_SET_TEXTURE_FORMAT_BASE_SIZE_U               0x00F00000
+#       define NV097_SET_TEXTURE_FORMAT_BASE_SIZE_V               0x0F000000
+#       define NV097_SET_TEXTURE_FORMAT_BASE_SIZE_P               0xF0000000
+#   define NV097_SET_TEXTURE_ADDRESS                          0x00001B08
+#   define NV097_SET_TEXTURE_CONTROL0                         0x00001B0C
+#       define NV097_SET_TEXTURE_CONTROL0_ENABLE                 (1 << 30)
+#       define NV097_SET_TEXTURE_CONTROL0_MIN_LOD_CLAMP           0x3FFC0000
+#       define NV097_SET_TEXTURE_CONTROL0_MAX_LOD_CLAMP           0x0003FFC0
+#   define NV097_SET_TEXTURE_CONTROL1                         0x00001B10
+#       define NV097_SET_TEXTURE_CONTROL1_IMAGE_PITCH             0xFFFF0000
+#   define NV097_SET_TEXTURE_FILTER                           0x00001B14
+#       define NV097_SET_TEXTURE_FILTER_MIPMAP_LOD_BIAS           0x00001FFF
+#       define NV097_SET_TEXTURE_FILTER_MIN                       0x00FF0000
+#       define NV097_SET_TEXTURE_FILTER_MAG                       0x0F000000
+#       define NV097_SET_TEXTURE_FILTER_ASIGNED                   (1 << 28)
+#       define NV097_SET_TEXTURE_FILTER_RSIGNED                   (1 << 29)
+#       define NV097_SET_TEXTURE_FILTER_GSIGNED                   (1 << 30)
+#       define NV097_SET_TEXTURE_FILTER_BSIGNED                   (1 << 31)
+#   define NV097_SET_TEXTURE_IMAGE_RECT                       0x00001B1C
+#       define NV097_SET_TEXTURE_IMAGE_RECT_WIDTH                 0xFFFF0000
+#       define NV097_SET_TEXTURE_IMAGE_RECT_HEIGHT                0x0000FFFF
+#   define NV097_SET_TEXTURE_PALETTE                          0x00001B20
+#       define NV097_SET_TEXTURE_PALETTE_CONTEXT_DMA              (1 << 0)
+#       define NV097_SET_TEXTURE_PALETTE_LENGTH                   0x0000000C
+#         define NV097_SET_TEXTURE_PALETTE_LENGTH_256               0
+#         define NV097_SET_TEXTURE_PALETTE_LENGTH_128               1
+#         define NV097_SET_TEXTURE_PALETTE_LENGTH_64                2
+#         define NV097_SET_TEXTURE_PALETTE_LENGTH_32                3
+#       define NV097_SET_TEXTURE_PALETTE_OFFSET                   0xFFFFFFC0
+#   define NV097_SET_TEXTURE_BORDER_COLOR                     0x00001B24
+#   define NV097_SET_TEXTURE_SET_BUMP_ENV_MAT                 0x00001B28
+#   define NV097_SET_TEXTURE_SET_BUMP_ENV_SCALE               0x00001B38
+#   define NV097_SET_TEXTURE_SET_BUMP_ENV_OFFSET              0x00001B3C
+#   define NV097_SET_SEMAPHORE_OFFSET                         0x00001D6C
+#   define NV097_BACK_END_WRITE_SEMAPHORE_RELEASE             0x00001D70
+#   define NV097_SET_ZSTENCIL_CLEAR_VALUE                     0x00001D8C
+#   define NV097_SET_COLOR_CLEAR_VALUE                        0x00001D90
+#   define NV097_CLEAR_SURFACE                                0x00001D94
+#       define NV097_CLEAR_SURFACE_Z                              (1 << 0)
+#       define NV097_CLEAR_SURFACE_STENCIL                        (1 << 1)
+#       define NV097_CLEAR_SURFACE_COLOR                          0x000000F0
+#       define NV097_CLEAR_SURFACE_R                                (1 << 4)
+#       define NV097_CLEAR_SURFACE_G                                (1 << 5)
+#       define NV097_CLEAR_SURFACE_B                                (1 << 6)
+#       define NV097_CLEAR_SURFACE_A                                (1 << 7)
+#   define NV097_SET_CLEAR_RECT_HORIZONTAL                    0x00001D98
+#   define NV097_SET_CLEAR_RECT_VERTICAL                      0x00001D9C
+#   define NV097_SET_SPECULAR_FOG_FACTOR                      0x00001E20
+#   define NV097_SET_COMBINER_COLOR_OCW                       0x00001E40
+#   define NV097_SET_COMBINER_CONTROL                         0x00001E60
+#   define NV097_SET_SHADOW_ZSLOPE_THRESHOLD                  0x00001E68
+#   define NV097_SET_SHADER_STAGE_PROGRAM                     0x00001E70
+#   define NV097_SET_SHADER_OTHER_STAGE_INPUT                 0x00001E78
+#   define NV097_SET_TRANSFORM_EXECUTION_MODE                 0x00001E94
+#       define NV097_SET_TRANSFORM_EXECUTION_MODE_MODE            0x00000003
+#       define NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE      0xFFFFFFFC
+#   define NV097_SET_TRANSFORM_PROGRAM_CXT_WRITE_EN           0x00001E98
+#   define NV097_SET_TRANSFORM_PROGRAM_LOAD                   0x00001E9C
+#   define NV097_SET_TRANSFORM_PROGRAM_START                  0x00001EA0
+#   define NV097_SET_TRANSFORM_CONSTANT_LOAD                  0x00001EA4
+
+/* vertex processing (cheops) context layout */
+#define NV_IGRAPH_XF_XFCTX_CMAT0                     0x00
+#define NV_IGRAPH_XF_XFCTX_PMAT0                     0x04
+#define NV_IGRAPH_XF_XFCTX_MMAT0                     0x08
+#define NV_IGRAPH_XF_XFCTX_IMMAT0                    0x0c
+#define NV_IGRAPH_XF_XFCTX_MMAT1                     0x10
+#define NV_IGRAPH_XF_XFCTX_IMMAT1                    0x14
+#define NV_IGRAPH_XF_XFCTX_MMAT2                     0x18
+#define NV_IGRAPH_XF_XFCTX_IMMAT2                    0x1c
+#define NV_IGRAPH_XF_XFCTX_MMAT3                     0x20
+#define NV_IGRAPH_XF_XFCTX_IMMAT3                    0x24
+#define NV_IGRAPH_XF_XFCTX_LIT0                      0x28
+#define NV_IGRAPH_XF_XFCTX_LIT1                      0x29
+#define NV_IGRAPH_XF_XFCTX_LIT2                      0x2a
+#define NV_IGRAPH_XF_XFCTX_LIT3                      0x2b
+#define NV_IGRAPH_XF_XFCTX_LIT4                      0x2c
+#define NV_IGRAPH_XF_XFCTX_LIT5                      0x2d
+#define NV_IGRAPH_XF_XFCTX_LIT6                      0x2e
+#define NV_IGRAPH_XF_XFCTX_LIT7                      0x2f
+#define NV_IGRAPH_XF_XFCTX_SPOT0                     0x30
+#define NV_IGRAPH_XF_XFCTX_SPOT1                     0x31
+#define NV_IGRAPH_XF_XFCTX_SPOT2                     0x32
+#define NV_IGRAPH_XF_XFCTX_SPOT3                     0x33
+#define NV_IGRAPH_XF_XFCTX_SPOT4                     0x34
+#define NV_IGRAPH_XF_XFCTX_SPOT5                     0x35
+#define NV_IGRAPH_XF_XFCTX_SPOT6                     0x36
+#define NV_IGRAPH_XF_XFCTX_SPOT7                     0x37
+#define NV_IGRAPH_XF_XFCTX_EYEP                      0x38
+#define NV_IGRAPH_XF_XFCTX_FOG                       0x39
+#define NV_IGRAPH_XF_XFCTX_VPSCL                     0x3a
+#define NV_IGRAPH_XF_XFCTX_VPOFF                     0x3b
+#define NV_IGRAPH_XF_XFCTX_CONS0                     0x3c
+#define NV_IGRAPH_XF_XFCTX_CONS1                     0x3d
+#define NV_IGRAPH_XF_XFCTX_CONS2                     0x3e
+#define NV_IGRAPH_XF_XFCTX_CONS3                     0x3f
+#define NV_IGRAPH_XF_XFCTX_TG0MAT                    0x40
+#define NV_IGRAPH_XF_XFCTX_T0MAT                     0x44
+#define NV_IGRAPH_XF_XFCTX_TG1MAT                    0x48
+#define NV_IGRAPH_XF_XFCTX_T1MAT                     0x4c
+#define NV_IGRAPH_XF_XFCTX_TG2MAT                    0x50
+#define NV_IGRAPH_XF_XFCTX_T2MAT                     0x54
+#define NV_IGRAPH_XF_XFCTX_TG3MAT                    0x58
+#define NV_IGRAPH_XF_XFCTX_T3MAT                     0x5c
+#define NV_IGRAPH_XF_XFCTX_PRSPACE                   0x60
+
+/* lighting (zoser) context layout */
+#define NV_IGRAPH_XF_LTCTXA_L0_K                     0x00
+#define NV_IGRAPH_XF_LTCTXA_L0_SPT                   0x01
+#define NV_IGRAPH_XF_LTCTXA_L1_K                     0x02
+#define NV_IGRAPH_XF_LTCTXA_L1_SPT                   0x03
+#define NV_IGRAPH_XF_LTCTXA_L2_K                     0x04
+#define NV_IGRAPH_XF_LTCTXA_L2_SPT                   0x05
+#define NV_IGRAPH_XF_LTCTXA_L3_K                     0x06
+#define NV_IGRAPH_XF_LTCTXA_L3_SPT                   0x07
+#define NV_IGRAPH_XF_LTCTXA_L4_K                     0x08
+#define NV_IGRAPH_XF_LTCTXA_L4_SPT                   0x09
+#define NV_IGRAPH_XF_LTCTXA_L5_K                     0x0a
+#define NV_IGRAPH_XF_LTCTXA_L5_SPT                   0x0b
+#define NV_IGRAPH_XF_LTCTXA_L6_K                     0x0c
+#define NV_IGRAPH_XF_LTCTXA_L6_SPT                   0x0d
+#define NV_IGRAPH_XF_LTCTXA_L7_K                     0x0e
+#define NV_IGRAPH_XF_LTCTXA_L7_SPT                   0x0f
+#define NV_IGRAPH_XF_LTCTXA_EYED                     0x10
+#define NV_IGRAPH_XF_LTCTXA_FR_AMB                   0x11
+#define NV_IGRAPH_XF_LTCTXA_BR_AMB                   0x12
+#define NV_IGRAPH_XF_LTCTXA_CM_COL                   0x13
+#define NV_IGRAPH_XF_LTCTXA_BCM_COL                  0x14
+#define NV_IGRAPH_XF_LTCTXA_FOG_K                    0x15
+#define NV_IGRAPH_XF_LTCTXA_ZERO                     0x16
+#define NV_IGRAPH_XF_LTCTXA_PT0                      0x17
+#define NV_IGRAPH_XF_LTCTXA_FOGLIN                   0x18
+
+#define NV_IGRAPH_XF_LTCTXB_L0_AMB                   0x00
+#define NV_IGRAPH_XF_LTCTXB_L0_DIF                   0x01
+#define NV_IGRAPH_XF_LTCTXB_L0_SPC                   0x02
+#define NV_IGRAPH_XF_LTCTXB_L0_BAMB                  0x03
+#define NV_IGRAPH_XF_LTCTXB_L0_BDIF                  0x04
+#define NV_IGRAPH_XF_LTCTXB_L0_BSPC                  0x05
+#define NV_IGRAPH_XF_LTCTXB_L1_AMB                   0x06
+#define NV_IGRAPH_XF_LTCTXB_L1_DIF                   0x07
+#define NV_IGRAPH_XF_LTCTXB_L1_SPC                   0x08
+#define NV_IGRAPH_XF_LTCTXB_L1_BAMB                  0x09
+#define NV_IGRAPH_XF_LTCTXB_L1_BDIF                  0x0a
+#define NV_IGRAPH_XF_LTCTXB_L1_BSPC                  0x0b
+#define NV_IGRAPH_XF_LTCTXB_L2_AMB                   0x0c
+#define NV_IGRAPH_XF_LTCTXB_L2_DIF                   0x0d
+#define NV_IGRAPH_XF_LTCTXB_L2_SPC                   0x0e
+#define NV_IGRAPH_XF_LTCTXB_L2_BAMB                  0x0f
+#define NV_IGRAPH_XF_LTCTXB_L2_BDIF                  0x10
+#define NV_IGRAPH_XF_LTCTXB_L2_BSPC                  0x11
+#define NV_IGRAPH_XF_LTCTXB_L3_AMB                   0x12
+#define NV_IGRAPH_XF_LTCTXB_L3_DIF                   0x13
+#define NV_IGRAPH_XF_LTCTXB_L3_SPC                   0x14
+#define NV_IGRAPH_XF_LTCTXB_L3_BAMB                  0x15
+#define NV_IGRAPH_XF_LTCTXB_L3_BDIF                  0x16
+#define NV_IGRAPH_XF_LTCTXB_L3_BSPC                  0x17
+#define NV_IGRAPH_XF_LTCTXB_L4_AMB                   0x18
+#define NV_IGRAPH_XF_LTCTXB_L4_DIF                   0x19
+#define NV_IGRAPH_XF_LTCTXB_L4_SPC                   0x1a
+#define NV_IGRAPH_XF_LTCTXB_L4_BAMB                  0x1b
+#define NV_IGRAPH_XF_LTCTXB_L4_BDIF                  0x1c
+#define NV_IGRAPH_XF_LTCTXB_L4_BSPC                  0x1d
+#define NV_IGRAPH_XF_LTCTXB_L5_AMB                   0x1e
+#define NV_IGRAPH_XF_LTCTXB_L5_DIF                   0x1f
+#define NV_IGRAPH_XF_LTCTXB_L5_SPC                   0x20
+#define NV_IGRAPH_XF_LTCTXB_L5_BAMB                  0x21
+#define NV_IGRAPH_XF_LTCTXB_L5_BDIF                  0x22
+#define NV_IGRAPH_XF_LTCTXB_L5_BSPC                  0x23
+#define NV_IGRAPH_XF_LTCTXB_L6_AMB                   0x24
+#define NV_IGRAPH_XF_LTCTXB_L6_DIF                   0x25
+#define NV_IGRAPH_XF_LTCTXB_L6_SPC                   0x26
+#define NV_IGRAPH_XF_LTCTXB_L6_BAMB                  0x27
+#define NV_IGRAPH_XF_LTCTXB_L6_BDIF                  0x28
+#define NV_IGRAPH_XF_LTCTXB_L6_BSPC                  0x29
+#define NV_IGRAPH_XF_LTCTXB_L7_AMB                   0x2a
+#define NV_IGRAPH_XF_LTCTXB_L7_DIF                   0x2b
+#define NV_IGRAPH_XF_LTCTXB_L7_SPC                   0x2c
+#define NV_IGRAPH_XF_LTCTXB_L7_BAMB                  0x2d
+#define NV_IGRAPH_XF_LTCTXB_L7_BDIF                  0x2e
+#define NV_IGRAPH_XF_LTCTXB_L7_BSPC                  0x2f
+#define NV_IGRAPH_XF_LTCTXB_PT1                      0x30
+#define NV_IGRAPH_XF_LTCTXB_ONE                      0x31
+#define NV_IGRAPH_XF_LTCTXB_VPOFFSET                 0x32
+
+#define NV_IGRAPH_XF_LTC1_ZERO1                      0x00
+#define NV_IGRAPH_XF_LTC1_l0                         0x01
+#define NV_IGRAPH_XF_LTC1_Bl0                        0x02
+#define NV_IGRAPH_XF_LTC1_PP                         0x03
+#define NV_IGRAPH_XF_LTC1_r0                         0x04
+#define NV_IGRAPH_XF_LTC1_r1                         0x05
+#define NV_IGRAPH_XF_LTC1_r2                         0x06
+#define NV_IGRAPH_XF_LTC1_r3                         0x07
+#define NV_IGRAPH_XF_LTC1_r4                         0x08
+#define NV_IGRAPH_XF_LTC1_r5                         0x09
+#define NV_IGRAPH_XF_LTC1_r6                         0x0a
+#define NV_IGRAPH_XF_LTC1_r7                         0x0b
+#define NV_IGRAPH_XF_LTC1_L0                         0x0c
+#define NV_IGRAPH_XF_LTC1_L1                         0x0d
+#define NV_IGRAPH_XF_LTC1_L2                         0x0e
+#define NV_IGRAPH_XF_LTC1_L3                         0x0f
+#define NV_IGRAPH_XF_LTC1_L4                         0x10
+#define NV_IGRAPH_XF_LTC1_L5                         0x11
+#define NV_IGRAPH_XF_LTC1_L6                         0x12
+#define NV_IGRAPH_XF_LTC1_L7                         0x13
+
+
+#define NV2A_VERTEX_ATTR_POSITION       0
+#define NV2A_VERTEX_ATTR_WEIGHT         1
+#define NV2A_VERTEX_ATTR_NORMAL         2
+#define NV2A_VERTEX_ATTR_DIFFUSE        3
+#define NV2A_VERTEX_ATTR_SPECULAR       4
+#define NV2A_VERTEX_ATTR_FOG            5
+#define NV2A_VERTEX_ATTR_POINT_SIZE     6
+#define NV2A_VERTEX_ATTR_BACK_DIFFUSE   7
+#define NV2A_VERTEX_ATTR_BACK_SPECULAR  8
+#define NV2A_VERTEX_ATTR_TEXTURE0       9
+#define NV2A_VERTEX_ATTR_TEXTURE1       10
+#define NV2A_VERTEX_ATTR_TEXTURE2       11
+#define NV2A_VERTEX_ATTR_TEXTURE3       12
+#define NV2A_VERTEX_ATTR_RESERVED1      13
+#define NV2A_VERTEX_ATTR_RESERVED2      14
+#define NV2A_VERTEX_ATTR_RESERVED3      15
+
+#define NV2A_CRYSTAL_FREQ 16666666
+#define NV2A_NUM_CHANNELS 32
+#define NV2A_NUM_SUBCHANNELS 8
+#define NV2A_CACHE1_SIZE 128
+
+#define NV2A_MAX_BATCH_LENGTH 0x1FFFF
+#define NV2A_VERTEXSHADER_ATTRIBUTES 16
+#define NV2A_MAX_TEXTURES 4
+
+#define NV2A_MAX_TRANSFORM_PROGRAM_LENGTH 136
+#define NV2A_VERTEXSHADER_CONSTANTS 192
+#define NV2A_MAX_LIGHTS 8
+
+#define NV2A_LTCTXA_COUNT  26
+#define NV2A_LTCTXB_COUNT  52
+#define NV2A_LTC1_COUNT    20
+
+#endif

--- a/lib/xgu/xgu.h
+++ b/lib/xgu/xgu.h
@@ -1,0 +1,696 @@
+#ifndef __XGU_H
+#define __XGU_H
+
+#include <assert.h>
+#include <pbkit/pbkit.h>
+// Hack until we fix pbkit/outer.h (or stop including it)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmacro-redefined"
+#include "nv2a_regs.h"
+#pragma GCC diagnostic pop
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <xboxrt/libc_extensions/strings.h>
+#include <string.h>
+
+typedef enum {
+    //FIXME: define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_UB_D3D     0
+    //FIXME: define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_S1         1
+    XGU_FLOAT = NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
+    //FIXME: define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_UB_OGL     4
+    //FIXME: define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_S32K       5
+    //FIXME: define NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_CMP        6
+} XguVertexArrayType;
+
+typedef enum {
+    XGU_END = NV097_SET_BEGIN_END_OP_END, // FIXME: Disallow this one?
+    XGU_POINTS = NV097_SET_BEGIN_END_OP_POINTS,
+    XGU_LINES = NV097_SET_BEGIN_END_OP_LINES,
+    XGU_LINE_LOOP = NV097_SET_BEGIN_END_OP_LINE_LOOP,
+    XGU_LINE_STRIP = NV097_SET_BEGIN_END_OP_LINE_STRIP,
+    XGU_TRIANGLES = NV097_SET_BEGIN_END_OP_TRIANGLES,
+    XGU_TRIANGLE_STRIP = NV097_SET_BEGIN_END_OP_TRIANGLE_STRIP,
+    XGU_TRIANGLE_FAN = NV097_SET_BEGIN_END_OP_TRIANGLE_FAN,
+    XGU_QUADS = NV097_SET_BEGIN_END_OP_QUADS,
+    XGU_QUAD_STRIP = NV097_SET_BEGIN_END_OP_QUAD_STRIP,
+    XGU_POLYGON = NV097_SET_BEGIN_END_OP_POLYGON
+} XguPrimitiveType;
+
+typedef enum {
+    XGU_VERTEX_ARRAY = NV2A_VERTEX_ATTR_POSITION,
+    XGU_NORMAL_ARRAY = NV2A_VERTEX_ATTR_NORMAL,
+    XGU_COLOR_ARRAY = NV2A_VERTEX_ATTR_DIFFUSE,
+    XGU_SECONDARY_COLOR_ARRAY = NV2A_VERTEX_ATTR_SPECULAR,
+    XGU_FOG_ARRAY = NV2A_VERTEX_ATTR_FOG,
+    XGU_TEXCOORD0_ARRAY = NV2A_VERTEX_ATTR_TEXTURE0,
+    XGU_TEXCOORD1_ARRAY = NV2A_VERTEX_ATTR_TEXTURE1,
+    XGU_TEXCOORD2_ARRAY = NV2A_VERTEX_ATTR_TEXTURE2,
+    XGU_TEXCOORD3_ARRAY = NV2A_VERTEX_ATTR_TEXTURE3
+} XguVertexArray;
+
+typedef enum {
+    XGU_FIXED = NV097_SET_TRANSFORM_EXECUTION_MODE_MODE_FIXED,
+    XGU_PROGRAM = NV097_SET_TRANSFORM_EXECUTION_MODE_MODE_PROGRAM
+} XguExecMode;
+
+typedef enum {
+    XGU_RANGE_MODE_USER = 0 /*NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE_USER*/,
+    XGU_RANGE_MODE_PRIVATE = 1 /*NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE_PRIVATE */
+} XguExecRange;
+
+typedef enum {
+    XGU_CLEAR_Z = NV097_CLEAR_SURFACE_Z,
+    XGU_CLEAR_STENCIL = NV097_CLEAR_SURFACE_STENCIL,
+    XGU_CLEAR_COLOR = NV097_CLEAR_SURFACE_COLOR,
+    XGU_CLEAR_R = NV097_CLEAR_SURFACE_R,
+    XGU_CLEAR_G = NV097_CLEAR_SURFACE_G,
+    XGU_CLEAR_B = NV097_CLEAR_SURFACE_B,
+    XGU_CLEAR_A = NV097_CLEAR_SURFACE_A
+} XguClearSurface;
+
+/*
+ * SFACTOR and DFACTOR share the same values for their respective defines.
+ * Thus no duplicate table was created.
+ */
+typedef enum {
+    XGU_FACTOR_ZERO = NV097_SET_BLEND_FUNC_SFACTOR_V_ZERO,
+    XGU_FACTOR_ONE = NV097_SET_BLEND_FUNC_SFACTOR_V_ONE,
+    XGU_FACTOR_SRC_COLOR = NV097_SET_BLEND_FUNC_SFACTOR_V_SRC_COLOR,
+    XGU_FACTOR_ONE_MINUS_SRC_COLOR = NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_SRC_COLOR,
+    XGU_FACTOR_SRC_ALPHA = NV097_SET_BLEND_FUNC_SFACTOR_V_SRC_ALPHA,
+    XGU_FACTOR_ONE_MINUS_SRC_ALPHA = NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_SRC_ALPHA,
+    XGU_FACTOR_DST_ALPHA = NV097_SET_BLEND_FUNC_SFACTOR_V_DST_ALPHA,
+    XGU_FACTOR_ONE_MINUS_DST_ALPHA = NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_DST_ALPHA,
+    XGU_FACTOR_DST_COLOR = NV097_SET_BLEND_FUNC_SFACTOR_V_DST_COLOR,
+    XGU_FACTOR_ONE_MINUS_DST_COLOR = NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_DST_COLOR,
+    XGU_FACTOR_SRC_ALPHA_SATURATE = NV097_SET_BLEND_FUNC_SFACTOR_V_SRC_ALPHA_SATURATE,
+    XGU_FACTOR_CONSTANT_COLOR = NV097_SET_BLEND_FUNC_SFACTOR_V_CONSTANT_COLOR,
+    XGU_FACTOR_ONE_MINUS_CONSTANT_COLOR = NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_CONSTANT_COLOR,
+    XGU_FACTOR_CONSTANT_ALPHA = NV097_SET_BLEND_FUNC_SFACTOR_V_CONSTANT_ALPHA,
+    XGU_FACTOR_ONE_MINUS_CONSTANT_ALPHA = NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_CONSTANT_ALPHA
+} XguBlendFactor;
+
+typedef enum {
+    XGU_BLUE = NV097_SET_COLOR_MASK_BLUE_WRITE_ENABLE,
+    XGU_GREEN = NV097_SET_COLOR_MASK_GREEN_WRITE_ENABLE,
+    XGU_RED = NV097_SET_COLOR_MASK_RED_WRITE_ENABLE,
+    XGU_ALPHA = NV097_SET_COLOR_MASK_ALPHA_WRITE_ENABLE
+} XguColorMask;
+
+typedef enum {
+    XGU_POINT = NV097_SET_FRONT_POLYGON_MODE_V_POINT,
+    XGU_LINE = NV097_SET_FRONT_POLYGON_MODE_V_LINE,
+    XGU_FILL = NV097_SET_FRONT_POLYGON_MODE_V_FILL
+} XguPolygonMode;
+
+typedef enum {
+    XGU_CULL_FRONT = NV097_SET_CULL_FACE_V_FRONT,
+    XGU_CULL_BACK = NV097_SET_CULL_FACE_V_BACK,
+    XGU_CULL_FRONT_AND_BACK = NV097_SET_CULL_FACE_V_FRONT_AND_BACK
+} XguCullFace;
+
+typedef enum {
+    XGU_TEXGEN_DISABLE = NV097_SET_TEXGEN_S_DISABLE,
+    XGU_TEXGEN_EYE_LINEAR = NV097_SET_TEXGEN_S_EYE_LINEAR,
+    XGU_TEXGEN_OBJECT_LINEAR = NV097_SET_TEXGEN_S_OBJECT_LINEAR,
+    XGU_TEXGEN_SPHERE_MAP = NV097_SET_TEXGEN_S_SPHERE_MAP,
+    XGU_TEXGEN_REFLECTION_MAP = NV097_SET_TEXGEN_S_REFLECTION_MAP,
+    XGU_TEXGEN_NORMAL_MAP = NV097_SET_TEXGEN_S_NORMAL_MAP
+} XguTexgen;
+
+typedef enum {
+    XGU_STENCIL_OP_KEEP = NV097_SET_STENCIL_OP_V_KEEP,
+    XGU_STENCIL_OP_ZERO = NV097_SET_STENCIL_OP_V_ZERO,
+    XGU_STENCIL_OP_REPLACE = NV097_SET_STENCIL_OP_V_REPLACE,
+    XGU_STENCIL_OP_INCRSAT = NV097_SET_STENCIL_OP_V_INCRSAT,
+    XGU_STENCIL_OP_DECRSAT = NV097_SET_STENCIL_OP_V_DECRSAT,
+    XGU_STENCIL_OP_INVERT = NV097_SET_STENCIL_OP_V_INVERT,
+    XGU_STENCIL_OP_INCR = NV097_SET_STENCIL_OP_V_INCR,
+    XGU_STENCIL_OP_DECR = NV097_SET_STENCIL_OP_V_DECR
+} XguStencilOp;
+
+typedef enum {
+    XGU_FRONT_CW = NV097_SET_FRONT_FACE_V_CW,
+    XGU_FRONT_CCW = NV097_SET_FRONT_FACE_V_CCW
+} XguFrontFace;
+
+typedef enum {
+    XGU_LMASK_OFF = NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_OFF,
+    XGU_LMASK_INFINITE = NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_INFINITE,
+    XGU_LMASK_LOCAL = NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_LOCAL,
+    XGU_LMASK_SPOT = NV097_SET_LIGHT_ENABLE_MASK_LIGHT0_SPOT
+} XguLightMask;
+
+#define XGU_MASK(mask, val) (((val) << (ffs(mask)-1)) & (mask))
+
+#define XGU_ATTRIBUTE_COUNT 16
+#define XGU_TEXTURE_COUNT 4
+#define XGU_WEIGHT_COUNT 4
+#define XGU_LIGHT_COUNT 8
+
+typedef union {
+    float f[3];
+    struct {
+        float x, y, z;
+    };
+    struct {
+        float r, g, b;
+    };
+} XguVec3;
+
+typedef union {
+    float f[4];
+    struct {
+        float x, y, z, w;
+    };
+    struct {
+        float r, g, b, a;
+    };
+} XguVec4;
+
+typedef union {
+  float f[4*4];
+  XguVec4 col[4];
+} XguMatrix4x4;
+
+
+/* ========================= *
+ *  BEGIN PUSH HELPER BLOCK  *
+ * ========================= */
+
+static inline
+DWORD* push_command(DWORD* p, DWORD command, int nparams) {
+    pb_push(p++, command, nparams);
+    return p;
+}
+
+static inline
+DWORD* push_parameter(DWORD* p, DWORD parameter) {
+    *p++ = parameter;
+    return p;
+}
+
+static inline
+DWORD* push_boolean(DWORD* p, bool enabled) {
+    return push_parameter(p, enabled ? 1 : 0);
+}
+
+static inline
+DWORD* push_command_boolean(DWORD* p, DWORD command, bool enabled) {
+    p = push_command(p, command, 1);
+    p = push_boolean(p, enabled);
+    return p;
+}
+
+static inline
+DWORD* push_float(DWORD* p, float f) {
+    return push_parameter(p, *(uint32_t*)&f);
+}
+
+static inline
+DWORD* push_floats(DWORD* p, float* f, unsigned int count) {
+    for(unsigned int i = 0; i < count; i++) {
+        p = push_float(p, f[i]);
+    }
+    return p;
+}
+
+static inline
+DWORD* push_matrix2x2(DWORD* p, float m[2*2]) {
+    return push_floats(p, m, 2*2);
+}
+
+static inline
+DWORD* push_matrix4x4(DWORD* p, float m[4*4]) {
+    return push_floats(p, m, 4*4);
+}
+
+static inline
+DWORD* push_command_matrix2x2(DWORD* p, DWORD command, float m[2*2]) {
+    p = push_command(p, command, 2*2);
+    p = push_matrix2x2(p, m);
+    return p;
+}
+
+static inline
+DWORD* push_command_matrix4x4(DWORD* p, DWORD command, float m[4*4]) {
+    p = push_command(p, command, 4*4);
+    p = push_matrix4x4(p, m);
+    return p;
+}
+
+static inline
+DWORD* push_command_parameter(DWORD* p, DWORD command, DWORD parameter) {
+    p = push_command(p, command, 1);
+    p = push_parameter(p, parameter);
+    return p;
+}
+
+static inline
+DWORD* push_command_float(DWORD* p, DWORD command, float parameter) {
+    p = push_command(p, command, 1);
+    p = push_float(p, parameter);
+    return p;
+}
+
+
+/* ========================= *
+ * BEGIN XGU FUNCTIONS BLOCK *
+ * ========================= */
+
+inline
+DWORD* xgu_begin(DWORD* p, XguPrimitiveType type) {
+
+    // Force people to use xgu_end instead
+    assert(type != NV097_SET_BEGIN_END_OP_END);
+
+    return push_command_parameter(p, NV097_SET_BEGIN_END, type);
+}
+
+inline
+DWORD* xgu_end(DWORD* p) {
+    return push_command_parameter(p, NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
+}
+
+inline
+DWORD* xgu_no_operation(DWORD* p, uint32_t param) {
+    /* param is typically 0 */
+    return push_command_parameter(p, NV097_NO_OPERATION, param);
+}
+
+inline
+DWORD* xgu_wait_for_idle(DWORD* p) {
+    return push_command(p, NV097_WAIT_FOR_IDLE, 0);
+}
+
+inline
+DWORD* xgu_set_viewport_offset(DWORD* p, float x, float y, float z, float w) {
+    p = push_command(p, NV097_SET_VIEWPORT_OFFSET, 4);
+    p = push_float(p, x);
+    p = push_float(p, y);
+    p = push_float(p, z);
+    return push_float(p, w);
+}
+
+inline
+DWORD* xgu_set_viewport_scale(DWORD* p, float x, float y, float z, float w) {
+    p = push_command(p, NV097_SET_VIEWPORT_SCALE, 4);
+    p = push_float(p, x);
+    p = push_float(p, y);
+    p = push_float(p, z);
+    return push_float(p, w);
+}
+
+inline
+DWORD* xgu_set_clip_min(DWORD* p, float znear) {
+    return push_command_float(p, NV097_SET_CLIP_MIN, znear);
+}
+
+inline
+DWORD* xgu_set_clip_max(DWORD* p, float zfar) {
+    return push_command_float(p, NV097_SET_CLIP_MAX, zfar);
+}
+
+inline
+DWORD* xgu_set_zstencil_clear_value(DWORD* p, uint32_t value) {
+    return push_command_parameter(p, NV097_SET_ZSTENCIL_CLEAR_VALUE, value);
+}
+
+inline
+DWORD* xgu_set_color_clear_value(DWORD* p, DWORD color) {
+    return push_command_parameter(p, NV097_SET_COLOR_CLEAR_VALUE, color);
+}
+
+inline
+DWORD* xgu_clear_surface(DWORD* p, XguClearSurface flags) {
+    /*
+     * flags should probably be a combination of values -
+     * not sure if using an enum allows such magic and/or
+     * if it hinders out-of-bounds values.
+     */
+    return push_command_parameter(p, NV097_CLEAR_SURFACE, flags);
+}
+
+inline
+DWORD* xgu_set_clear_rect_horizontal(DWORD* p, uint32_t x1, uint32_t x2) {
+    return push_command_parameter(p, NV097_SET_CLEAR_RECT_HORIZONTAL,
+                                  ((x2-1)<<16)|x1);
+}
+
+inline
+DWORD* xgu_set_clear_rect_vertical(DWORD* p, uint32_t y1, uint32_t y2) {
+    return push_command_parameter(p, NV097_SET_CLEAR_RECT_VERTICAL,
+                                  ((y2-1)<<16)|y1);
+}
+
+inline
+DWORD* xgu_set_object(DWORD* p, uint32_t instance) {
+    return push_command_parameter(p, NV097_SET_OBJECT, instance);
+}
+
+inline
+DWORD* xgu_set_texgen_s(DWORD* p, uint32_t texture_index, XguTexgen tg) {
+    assert(texture_index == 0);
+    return push_command_parameter(p, NV097_SET_TEXGEN_S, tg);
+}
+
+inline
+DWORD* xgu_set_texgen_t(DWORD* p, uint32_t texture_index, XguTexgen tg) {
+    assert(texture_index == 0);
+    return push_command_parameter(p, NV097_SET_TEXGEN_T, tg);
+}
+
+inline
+DWORD* xgu_set_texgen_r(DWORD* p, uint32_t texture_index, XguTexgen tg) {
+    assert(texture_index == 0);
+    return push_command_parameter(p, NV097_SET_TEXGEN_R, tg);
+}
+
+inline
+DWORD* xgu_set_texgen_q(DWORD* p, uint32_t texture_index, XguTexgen tg) {
+    assert(texture_index == 0);
+    return push_command_parameter(p, NV097_SET_TEXGEN_Q, tg);
+}
+
+inline
+DWORD* xgu_set_texture_matrix_enable(DWORD* p, uint32_t texture_index, bool enabled) {
+    assert(texture_index == 0);
+    return push_command_boolean(p, NV097_SET_TEXTURE_MATRIX_ENABLE, enabled);
+}
+
+inline
+DWORD* xgu_set_projection_matrix(DWORD* p, float m[4*4]) {
+    return push_command_matrix4x4(p, NV097_SET_PROJECTION_MATRIX, m);
+}
+
+inline
+DWORD* xgu_set_model_view_matrix(DWORD* p, uint32_t bone_index, float m[4*4]) {
+    return push_command_matrix4x4(p, NV097_SET_MODEL_VIEW_MATRIX + bone_index*(4*4)*4, m);
+}
+
+inline
+DWORD* xgu_set_inverse_model_view_matrix(DWORD* p, uint32_t bone_index, float m[4*4]) {
+    return push_command_matrix4x4(p, NV097_SET_INVERSE_MODEL_VIEW_MATRIX + bone_index*(4*4)*4, m);
+}
+
+inline
+DWORD* xgu_set_composite_matrix(DWORD* p, float m[4*4]) {
+    return push_command_matrix4x4(p, NV097_SET_COMPOSITE_MATRIX, m);
+}
+
+inline
+DWORD* xgu_set_texture_matrix(DWORD* p, uint32_t slot, float m[4*4]) {
+    assert(slot == 0);
+    return push_command_matrix4x4(p, NV097_SET_TEXTURE_MATRIX, m);
+}
+
+/* ==== Stencil OP ==== */
+
+inline
+DWORD* xgu_set_stencil_op_fail(DWORD* p, XguStencilOp so) {
+    return push_command_parameter(p, NV097_SET_STENCIL_OP_FAIL, so);
+}
+
+inline
+DWORD* xgu_set_stencil_op_zfail(DWORD* p, XguStencilOp so) {
+    return push_command_parameter(p, NV097_SET_STENCIL_OP_ZFAIL, so);
+}
+
+inline
+DWORD* xgu_set_stencil_op_zpass(DWORD* p, XguStencilOp so) {
+    return push_command_parameter(p, NV097_SET_STENCIL_OP_ZPASS, so);
+}
+
+/* ==== Vertex Data Array ==== */
+
+inline
+DWORD* xgu_set_vertex_data_array_format(DWORD* p, XguVertexArray index, XguVertexArrayType format,
+                                        uint32_t size, uint32_t stride) {
+    return push_command_parameter(p, NV097_SET_VERTEX_DATA_ARRAY_FORMAT + index*4,
+                                  XGU_MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE, format) |
+                                  XGU_MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_SIZE, size) |
+                                  XGU_MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_STRIDE, stride));
+}
+
+inline
+DWORD* xgu_set_vertex_data_array_offset(DWORD* p, XguVertexArray index, const void* data) {
+    return push_command_parameter(p, NV097_SET_VERTEX_DATA_ARRAY_OFFSET + index*4,
+                                  (uint32_t)data/* & 0x03fffff*/);
+}
+
+inline
+DWORD* xgu_element16(DWORD* p, const uint16_t* elements, unsigned int count) {
+    assert(count % 2 == 0);
+    p = push_command(p, 0x40000000|NV097_ARRAY_ELEMENT16, count/2);
+    memcpy(p, elements, count * sizeof(uint16_t));
+    p += count / 2;
+    return p;
+}
+
+inline
+DWORD* xgu_element32(DWORD* p, const uint32_t* elements, unsigned int count) {
+    p = push_command(p, 0x40000000|NV097_ARRAY_ELEMENT32, count);
+    memcpy(p, elements, count * sizeof(uint32_t));
+    p += count;
+    return p;
+}
+
+inline
+DWORD* xgu_draw_arrays(DWORD* p, unsigned int start, unsigned int count) {
+    assert(count>=1);
+    assert(count<=256);
+    return push_command_parameter(p, 0x40000000|NV097_DRAW_ARRAYS,
+                                  XGU_MASK(NV097_DRAW_ARRAYS_COUNT, (count-1)) |
+                                  XGU_MASK(NV097_DRAW_ARRAYS_START_INDEX, start));
+}
+
+/* ==== Alpha/Blend/Cull ==== */
+inline
+DWORD* xgu_set_alpha_test_enable(DWORD* p, bool enabled) {
+    return push_command_boolean(p, NV097_SET_ALPHA_TEST_ENABLE, enabled);
+}
+
+inline
+DWORD* xgu_set_blend_enable(DWORD* p, bool enabled) {
+    return push_command_boolean(p, NV097_SET_BLEND_ENABLE, enabled);
+}
+
+inline
+DWORD* xgu_set_cull_face_enable(DWORD* p, bool enabled) {
+    return push_command_boolean(p, NV097_SET_CULL_FACE_ENABLE, enabled);
+}
+
+inline
+DWORD* xgu_set_depth_test_enable(DWORD* p, bool enabled) {
+    return push_command_boolean(p, NV097_SET_DEPTH_TEST_ENABLE, enabled);
+}
+
+inline
+DWORD* xgu_set_dither_enable(DWORD* p, bool enabled) {
+    return push_command_boolean(p, NV097_SET_DITHER_ENABLE, enabled);
+}
+
+inline
+DWORD* xgu_set_lighting_enable(DWORD* p, bool enabled) {
+    return push_command_boolean(p, NV097_SET_LIGHTING_ENABLE, enabled);
+}
+
+inline
+DWORD* xgu_set_stencil_test_enable(DWORD* p, bool enabled) {
+    return push_command_boolean(p, NV097_SET_STENCIL_TEST_ENABLE, enabled);
+}
+
+inline
+DWORD* xgu_set_alpha_func(DWORD* p, uint8_t func) {
+    return push_command_parameter(p, NV097_SET_ALPHA_FUNC, func);
+}
+
+inline
+DWORD* xgu_set_alpha_ref(DWORD* p, uint32_t ref) {
+    return push_command_parameter(p, NV097_SET_ALPHA_REF, ref);
+}
+
+inline
+DWORD* xgu_set_blend_func_sfactor(DWORD* p, XguBlendFactor sf) {
+    return push_command_parameter(p, NV097_SET_BLEND_FUNC_SFACTOR, sf);
+}
+
+inline
+DWORD* xgu_set_blend_func_dfactor(DWORD* p, XguBlendFactor df) {
+    return push_command_parameter(p, NV097_SET_BLEND_FUNC_DFACTOR, df);
+}
+
+inline
+DWORD* xgu_set_color_mask(DWORD* p, XguColorMask cm) {
+    return push_command_parameter(p, NV097_SET_COLOR_MASK, cm);
+}
+
+inline
+DWORD* xgu_set_front_polygon_mode(DWORD* p, XguPolygonMode pm) {
+    return push_command_parameter(p, NV097_SET_FRONT_POLYGON_MODE, pm);
+}
+
+inline
+DWORD* xgu_set_cull_face(DWORD* p, XguCullFace cf) {
+    return push_command_parameter(p, NV097_SET_CULL_FACE, cf);
+}
+
+inline
+DWORD* xgu_set_front_face(DWORD* p, XguFrontFace ff) {
+    return push_command_parameter(p, NV097_SET_FRONT_FACE, ff);
+}
+
+/* ==== Transform ==== */
+inline
+DWORD* xgu_set_transform_execution_mode(DWORD* p, XguExecMode mode, XguExecRange range) {
+    return push_command_parameter(p,
+                                  NV097_SET_TRANSFORM_EXECUTION_MODE,
+                                  XGU_MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_MODE, mode) |
+                                  XGU_MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE, range));
+}
+
+inline
+DWORD* xgu_set_transform_constant(DWORD* p, XguVec4 *v, unsigned int count) {
+    p = push_command(p, NV097_SET_TRANSFORM_CONSTANT, count*4);
+    for (uint32_t i = 0; i < count; ++i) {
+        p = push_floats(p, v[i].f, 4);
+    }
+    return p;
+}
+
+inline
+DWORD* xgu_set_transform_constant_load(DWORD* p, uint32_t offset) {
+    return push_command_parameter(p, NV097_SET_TRANSFORM_CONSTANT_LOAD, offset);
+}
+
+inline
+DWORD* xgu_set_transform_program(DWORD* p, XguVec4 *v, unsigned int count) {
+    p = push_command(p, NV097_SET_TRANSFORM_PROGRAM, count*4);
+    for (uint32_t i = 0; i < count; ++i) {
+        p = push_floats(p, v[i].f, 4);
+    }
+    return p;
+}
+
+inline
+DWORD* xgu_set_transform_program_start(DWORD* p, uint32_t offset) {
+    return push_command_parameter(p, NV097_SET_TRANSFORM_PROGRAM_START, offset);
+}
+
+inline
+DWORD* xgu_set_transform_program_load(DWORD* p, uint32_t offset) {
+    return push_command_parameter(p, NV097_SET_TRANSFORM_PROGRAM_LOAD, offset);
+}
+
+inline
+DWORD* xgu_set_transform_program_cxt_write_enable(DWORD* p, bool enabled) {
+    return push_command_boolean(p, NV097_SET_TRANSFORM_PROGRAM_CXT_WRITE_EN, enabled);
+}
+
+/* ==== Lights ==== */
+inline
+DWORD* xgu_set_light_enable_mask(DWORD* p, unsigned int light_index, XguLightMask lm) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    return push_command_parameter(p, NV097_SET_LIGHT_ENABLE_MASK, lm);
+}
+
+inline
+DWORD* xgu_set_back_light_ambient_color(DWORD* p, unsigned int light_index, DWORD color) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    return push_command_parameter(p, NV097_SET_BACK_LIGHT_AMBIENT_COLOR + light_index*4, color);
+}
+
+inline
+DWORD* xgu_set_back_light_diffuse_color(DWORD* p, unsigned int light_index, DWORD color) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    return push_command_parameter(p, NV097_SET_BACK_LIGHT_DIFFUSE_COLOR + light_index*4, color);
+}
+
+inline
+DWORD* xgu_set_back_light_specular_color(DWORD* p, unsigned int light_index, DWORD color) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    return push_command_parameter(p, NV097_SET_BACK_LIGHT_SPECULAR_COLOR + light_index*4, color);
+}
+
+inline
+DWORD* xgu_set_light_ambient_color(DWORD* p, unsigned int light_index, DWORD color) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    return push_command_parameter(p, NV097_SET_LIGHT_AMBIENT_COLOR + light_index*4, color);
+}
+
+inline
+DWORD* xgu_set_light_diffuse_color(DWORD* p, unsigned int light_index, DWORD color) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    return push_command_parameter(p, NV097_SET_LIGHT_DIFFUSE_COLOR + light_index*4, color);
+}
+
+inline
+DWORD* xgu_set_light_specular_color(DWORD* p, unsigned int light_index, DWORD color) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    return push_command_parameter(p, NV097_SET_LIGHT_SPECULAR_COLOR + light_index*4, color);
+}
+
+inline
+DWORD* xgu_set_light_local_range(DWORD* p, unsigned int light_index, float range) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    return push_command_float(p, NV097_SET_LIGHT_LOCAL_RANGE + light_index*4, range);
+}
+
+inline
+DWORD* xgu_set_light_infinite_half_vector(DWORD* p, unsigned int light_index, XguVec3 v) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    p = push_command(p, NV097_SET_LIGHT_INFINITE_HALF_VECTOR + light_index*3*4, 3);
+    return push_floats(p, v.f, 3);
+}
+
+inline
+DWORD* xgu_set_light_infinite_direction(DWORD* p, unsigned int light_index, XguVec3 v) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    p = push_command(p, NV097_SET_LIGHT_INFINITE_DIRECTION + light_index*3*4, 3);
+    return push_floats(p, v.f, 3);
+}
+
+inline
+DWORD* xgu_set_light_spot_falloff(DWORD* p, unsigned int light_index, XguVec3 v) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    p = push_command(p, NV097_SET_LIGHT_SPOT_FALLOFF + light_index*3*4, 3);
+    return push_floats(p, v.f, 3);
+}
+
+inline
+DWORD* xgu_set_light_spot_direction(DWORD* p, unsigned int light_index, XguVec4 v) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    p = push_command(p, NV097_SET_LIGHT_SPOT_DIRECTION + light_index*4*4, 4);
+    return push_floats(p, v.f, 4);
+}
+
+inline
+DWORD* xgu_set_light_local_position(DWORD* p, unsigned int light_index, XguVec3 v) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    p = push_command(p, NV097_SET_LIGHT_LOCAL_POSITION + light_index*3*4, 3);
+    return push_floats(p, v.f, 3);
+}
+
+inline
+DWORD* xgu_set_light_local_attenuation(DWORD* p, unsigned int light_index, XguVec3 v) {
+    assert(light_index >= 0);
+    assert(light_index < XGU_LIGHT_COUNT);
+    p = push_command(p, NV097_SET_LIGHT_LOCAL_ATTENUATION + light_index*3*4, 3);
+    return push_floats(p, v.f, 3);
+}
+
+#endif

--- a/lib/xgu/xgux.h
+++ b/lib/xgu/xgux.h
@@ -1,0 +1,116 @@
+#ifndef __XGUX_H
+#define __XGUX_H
+
+#include "xgu.h"
+
+#define MIN(a,b) ((a)<(b)?(a):(b))
+#define MAX_BATCH 120
+
+inline
+void xgux_draw_arrays(XguPrimitiveType mode, unsigned int start, unsigned int count) {
+    uint32_t *p = pb_begin();
+    p = xgu_begin(p, mode);
+    p = xgu_draw_arrays(p, start, count);
+    p = xgu_end(p);
+    pb_end(p);
+}
+
+inline
+void xgux_draw_elements16(XguPrimitiveType mode, unsigned int count, const uint16_t* elements) {
+    uint32_t *p = pb_begin();
+    p = xgu_begin(p, mode);
+
+    /* Submit elements in pairs if possible */
+    unsigned int pair_count = count / 2;
+    for (unsigned int i = 0; i < pair_count; ) {
+
+        if (i > 0) {
+            /* Start next batch */
+            pb_end(p);
+            p = pb_begin();
+        }
+
+        unsigned int batch_pair_count = MIN(MAX_BATCH, pair_count - i);
+        p = xgu_element16(p, &elements[i * 2], batch_pair_count * 2);
+
+        i += batch_pair_count;
+    }
+
+    /* Submit final index if necessary */
+    if (count % 2) {
+        uint32_t index = elements[count - 1];
+        p = xgu_element32(p, &index, 1);
+    }
+
+    p = xgu_end(p);
+    pb_end(p);
+}
+
+inline
+void xgux_draw_elements32(XguPrimitiveType mode, unsigned int count, const uint32_t* elements) {
+    uint32_t *p = pb_begin();
+    p = xgu_begin(p, mode);
+
+    /* Submit elements */
+    for (unsigned int i = 0; i < count; ) {
+
+        if (i > 0) {
+            /* Start next batch */
+            pb_end(p);
+            p = pb_begin();
+        }
+
+        unsigned int batch_count = MIN(MAX_BATCH, count - i);
+        p = xgu_element32(p, elements, batch_count);
+
+        i += batch_count;
+    }
+
+    p = xgu_end(p);
+    pb_end(p);
+}
+
+inline
+void xgux_set_clear_rect(unsigned int x, unsigned int y,
+                         unsigned int width, unsigned int height) {
+    uint32_t *p = pb_begin();
+    p = xgu_set_clear_rect_horizontal(p, x, x+width);
+    p = xgu_set_clear_rect_vertical(p, y, y+height);
+    pb_end(p);
+}
+
+inline
+void xgux_set_attrib_pointer(XguVertexArray index, XguVertexArrayType format, unsigned int size, unsigned int stride, const void* data) {
+    uint32_t *p = pb_begin();
+    p = xgu_set_vertex_data_array_format(p, index, format, size, stride);
+    p = xgu_set_vertex_data_array_offset(p, index, (uint32_t)data & 0x03ffffff);
+    pb_end(p);
+}
+
+
+inline
+void xgux_set_transform_constant_vec4(int location, unsigned int count, const XguVec4* v) {
+    uint32_t *p = pb_begin();
+    p = xgu_set_transform_constant_load(p, 96 + location);
+    p = xgu_set_transform_constant(p, v, count);
+    pb_end(p);
+}
+
+inline
+void xgux_set_transform_constant_matrix4x4(unsigned int location, unsigned int count, bool transpose, const XguMatrix4x4* m) {
+    for(unsigned int i = 0; i < count; i++) {
+        if (transpose) {
+            XguMatrix4x4 t;
+            for(unsigned int row = 0; row < 4; row++) {
+                for(unsigned int col = 0; col < 4; col++) {
+                    t.col[row].f[col] = m[i].col[col].f[row];
+                }
+            }
+            xgux_set_transform_constant_vec4(location + i*4, 4, &t.col);
+        } else {
+            xgux_set_transform_constant_vec4(location + i*4, 4, &m[i].col);
+        }
+    }
+}
+
+#endif

--- a/samples/mesh/main.c
+++ b/samples/mesh/main.c
@@ -142,26 +142,26 @@ void main(void)
 
         /* Enable texture stage 0 */
         /* FIXME: Use constants instead of the hardcoded values below */
-        p=pb_begin();
-        pb_push2(p,NV20_TCL_PRIMITIVE_3D_TX_OFFSET(0),(DWORD)texture.addr & 0x03ffffff,0x0001122a); p+=3; //set stage 0 texture address & format
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_NPOT_PITCH(0),texture.pitch<<16); p+=2; //set stage 0 texture pitch (pitch<<16)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_NPOT_SIZE(0),(texture.width<<16)|texture.height); p+=2; //set stage 0 texture width & height ((witdh<<16)|height)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(0),0x00030303); p+=2;//set stage 0 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(0),0x4003ffc0); p+=2; //set stage 0 texture enable flags
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(0),0x04074000); p+=2; //set stage 0 texture filters (AA!)
+        p = pb_begin();
+        p = pb_push2(p,NV20_TCL_PRIMITIVE_3D_TX_OFFSET(0),(DWORD)texture.addr & 0x03ffffff,0x0001122a); //set stage 0 texture address & format
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_NPOT_PITCH(0),texture.pitch<<16); //set stage 0 texture pitch (pitch<<16)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_NPOT_SIZE(0),(texture.width<<16)|texture.height); //set stage 0 texture width & height ((witdh<<16)|height)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(0),0x00030303);//set stage 0 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(0),0x4003ffc0); //set stage 0 texture enable flags
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(0),0x04074000); //set stage 0 texture filters (AA!)
         pb_end(p);
 
         /* Disable other texture stages */
-        p=pb_begin();
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(1),0x0003ffc0); p+=2;//set stage 1 texture enable flags (bit30 disabled)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(2),0x0003ffc0); p+=2;//set stage 2 texture enable flags (bit30 disabled)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(3),0x0003ffc0); p+=2;//set stage 3 texture enable flags (bit30 disabled)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(1),0x00030303); p+=2;//set stage 1 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(2),0x00030303); p+=2;//set stage 2 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(3),0x00030303); p+=2;//set stage 3 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(1),0x02022000); p+=2;//set stage 1 texture filters (no AA, stage not even used)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(2),0x02022000); p+=2;//set stage 2 texture filters (no AA, stage not even used)
-        pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(3),0x02022000); p+=2;//set stage 3 texture filters (no AA, stage not even used)
+        p = pb_begin();
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(1),0x0003ffc0);//set stage 1 texture enable flags (bit30 disabled)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(2),0x0003ffc0);//set stage 2 texture enable flags (bit30 disabled)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_ENABLE(3),0x0003ffc0);//set stage 3 texture enable flags (bit30 disabled)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(1),0x00030303);//set stage 1 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(2),0x00030303);//set stage 2 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_WRAP(3),0x00030303);//set stage 3 texture modes (0x0W0V0U wrapping: 1=wrap 2=mirror 3=clamp 4=border 5=clamp to edge)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(1),0x02022000);//set stage 1 texture filters (no AA, stage not even used)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(2),0x02022000);//set stage 2 texture filters (no AA, stage not even used)
+        p = pb_push1(p,NV20_TCL_PRIMITIVE_3D_TX_FILTER(3),0x02022000);//set stage 3 texture filters (no AA, stage not even used)
         pb_end(p);
 
         /* Send shader constants
@@ -173,7 +173,7 @@ void main(void)
         p = pb_begin();
 
         /* Set shader constants cursor at C0 */
-        pb_push1(p, NV20_TCL_PRIMITIVE_3D_VP_UPLOAD_CONST_ID, 96); p+=2;
+        p = pb_push1(p, NV20_TCL_PRIMITIVE_3D_VP_UPLOAD_CONST_ID, 96);
 
         /* Send the model matrix */
         pb_push(p++, NV20_TCL_PRIMITIVE_3D_VP_UPLOAD_CONST_X, 16);
@@ -297,20 +297,17 @@ static void init_shader(void)
     p = pb_begin();
 
     /* Set run address of shader */
-    pb_push(p++, NV097_SET_TRANSFORM_PROGRAM_START, 1); *(p++)=0;
+    p = pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_START, 0);
 
     /* Set execution mode */
-    pb_push1(p, NV097_SET_TRANSFORM_EXECUTION_MODE,
-        MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_MODE, NV097_SET_TRANSFORM_EXECUTION_MODE_MODE_PROGRAM)
-        | MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE, NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE_PRIV));
-    p += 2;
+    p = pb_push1(p, NV097_SET_TRANSFORM_EXECUTION_MODE,
+                 MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_MODE, NV097_SET_TRANSFORM_EXECUTION_MODE_MODE_PROGRAM)
+                 | MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE, NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE_PRIV));
 
-    pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_CXT_WRITE_EN, 0);
-    p += 2;
+    p = pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_CXT_WRITE_EN, 0);
 
     /* Set cursor and begin copying program */
-    pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_LOAD, 0);
-    p += 2;
+    p = pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_LOAD, 0);
 
     for (i=0; i<sizeof(vs_program)/8; i++) {
         pb_push(p++, NV097_SET_TRANSFORM_PROGRAM, 4);
@@ -340,13 +337,11 @@ static void init_textures(void)
 static void set_attrib_pointer(unsigned int index, unsigned int format, unsigned int size, unsigned int stride, const void* data)
 {
     uint32_t *p = pb_begin();
-    pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_FORMAT + index*4,
+    p = pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_FORMAT + index*4,
         MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE, format) | \
         MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_SIZE, size) | \
         MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_STRIDE, stride));
-    p += 2;
-    pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_OFFSET + index*4, (uint32_t)data & 0x03ffffff);
-    p += 2;
+    p = pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_OFFSET + index*4, (uint32_t)data & 0x03ffffff);
     pb_end(p);
 }
 
@@ -366,7 +361,7 @@ static void draw_indices(void)
 
         /* Begin by stating what these indices are and how many we'll send */
         p = pb_begin();
-        pb_push1(p, NV097_SET_BEGIN_END, TRIANGLES); p += 2;      
+        p = pb_push1(p, NV097_SET_BEGIN_END, TRIANGLES);
         pb_push(p++, 0x40000000|NV20_TCL_PRIMITIVE_3D_INDEX_DATA, num_this_batch);
 
         /* Send the indices */
@@ -374,7 +369,7 @@ static void draw_indices(void)
         p += num_this_batch;
 
         /* Finished with this batch */
-        pb_push1(p, NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END); p += 2;
+        p = pb_push1(p, NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
         pb_end(p);
 
         i += num_this_batch;

--- a/samples/mesh/main.c
+++ b/samples/mesh/main.c
@@ -7,11 +7,12 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 #include <pbkit/pbkit.h>
+#include <xgu/xgu.h>
+#include <xgu/xgux.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <windows.h>
 #include <xboxkrnl/xboxkrnl.h>
 #include <hal/debug.h>
@@ -208,10 +209,11 @@ void main(void)
         pb_push(p++, NV20_TCL_PRIMITIVE_3D_VP_UPLOAD_CONST_X, 4);
         memcpy(p, constants_0, 4*4); p+=4;
 
+        pb_end(p);
+        
         /* Clear all attributes */
-        pb_push(p++,NV097_SET_VERTEX_DATA_ARRAY_FORMAT,16);
-        for(i = 0; i < 16; i++) {
-            *(p++) = 2;
+        for(i = 0; i < XGU_ATTRIBUTE_COUNT; i++) {
+            xgux_set_attrib_pointer(i, XGU_FLOAT, 0, 0, NULL);
         }
         pb_end(p);
 
@@ -219,20 +221,16 @@ void main(void)
          * Setup vertex attributes
          */
 
-        /* Set vertex position attribute */
-        set_attrib_pointer(0, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
-                           3, sizeof(Vertex), &alloc_vertices[0]);
-        
-        /* Set vertex normal attribute */
-        set_attrib_pointer(2, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
-                           3, sizeof(Vertex), &alloc_vertices[3]);
-        
-        /* Set texture coordinate attribute */
-        set_attrib_pointer(8, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
-                           2, sizeof(Vertex), &alloc_vertices[6]);
+        xgux_set_attrib_pointer(XGU_VERTEX_ARRAY, XGU_FLOAT, 3,
+                           sizeof(Vertex), &alloc_vertices[0]);
+        xgux_set_attrib_pointer(XGU_NORMAL_ARRAY, XGU_FLOAT, 3,
+                           sizeof(Vertex), &alloc_vertices[3]);
+        xgux_set_attrib_pointer(8 /*XGU_TEXCOORD0_ARRAY*/, XGU_FLOAT, 2, //FIXME: Bug in XQEMU nv2a_regs.h
+                           sizeof(Vertex), &alloc_vertices[6]);
+
 
         /* Begin drawing triangles */
-        draw_indices();
+        xgux_draw_elements16(XGU_TRIANGLES, num_indices * 2, indices);
 
         /* Draw some text on the screen */
         pb_print("Mesh Demo\n");
@@ -331,47 +329,4 @@ static void init_textures(void)
     texture.pitch = texture.width*4;
     texture.addr = MmAllocateContiguousMemoryEx(texture.pitch*texture.height, 0, MAXRAM, 0, 0x404);
     memcpy(texture.addr, texture_rgba, sizeof(texture_rgba));
-}
-
-/* Set an attribute pointer */
-static void set_attrib_pointer(unsigned int index, unsigned int format, unsigned int size, unsigned int stride, const void* data)
-{
-    uint32_t *p = pb_begin();
-    p = pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_FORMAT + index*4,
-        MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE, format) | \
-        MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_SIZE, size) | \
-        MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_STRIDE, stride));
-    p = pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_OFFSET + index*4, (uint32_t)data & 0x03ffffff);
-    pb_end(p);
-}
-
-/* Draw vertices using the index method */
-static void draw_indices(void)
-{
-    /* Indices are already packed as dwords, so we simply send them out in batches */
-    #define MIN(a,b) ((a)<(b)?(a):(b))
-    #define MAX_BATCH 120
-
-    DWORD *p;
-    unsigned int i, num_this_batch;
-
-    for (i = 0; i < num_indices; ) {
-        /* Determine how many can be sent in this batch */
-        num_this_batch = MIN(MAX_BATCH, num_indices-i);
-
-        /* Begin by stating what these indices are and how many we'll send */
-        p = pb_begin();
-        p = pb_push1(p, NV097_SET_BEGIN_END, TRIANGLES);
-        pb_push(p++, 0x40000000|NV20_TCL_PRIMITIVE_3D_INDEX_DATA, num_this_batch);
-
-        /* Send the indices */
-        memcpy(p, &indices[i], num_this_batch * sizeof(uint32_t));
-        p += num_this_batch;
-
-        /* Finished with this batch */
-        p = pb_push1(p, NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END);
-        pb_end(p);
-
-        i += num_this_batch;
-    }
 }

--- a/samples/triangle/main.c
+++ b/samples/triangle/main.c
@@ -117,15 +117,15 @@ void main(void)
         pb_end(p);
 
         /* Set vertex position attribute */
-        set_attrib_pointer(XGU_VERTEX_ARRAY, XGU_FLOAT,
+        xgux_set_attrib_pointer(XGU_VERTEX_ARRAY, XGU_FLOAT,
                            3, sizeof(ColoredVertex), &alloc_vertices[0]);
 
         /* Set vertex diffuse color attribute */
-        set_attrib_pointer(XGU_COLOR_ARRAY, XGU_FLOAT,
+        xgux_set_attrib_pointer(XGU_COLOR_ARRAY, XGU_FLOAT,
                            3, sizeof(ColoredVertex), &alloc_vertices[3]);
 
         /* Begin drawing triangles */
-        draw_arrays(XGU_TRIANGLES, 0, num_vertices);
+        xgux_draw_arrays(XGU_TRIANGLES, 0, num_vertices);
 
         /* Draw some text on the screen */
         pb_print("Triangle Demo\n");
@@ -206,23 +206,4 @@ static void init_shader(void)
     p = pb_begin();
     #include "ps.inl"
     pb_end(p);
-}
-
-/* Set an attribute pointer */
-static void set_attrib_pointer(XguVertexArray index, XguVertexArrayType format, unsigned int size, unsigned int stride, const void* data)
-{
-    uint32_t *p = pb_begin();
-    p = xgu_set_vertex_data_array_format(p, index, format, size, stride);
-    p = xgu_set_vertex_data_array_offset(p, index, (uint32_t)data & 0x03ffffff);
-    p = pb_end(p);
-}
-
-/* Send draw commands for the triangles */
-static void draw_arrays(XguPrimitiveType mode, int start, int count)
-{
-    uint32_t *p = pb_begin();
-    p = xgu_begin(p, mode);
-    p = xgu_draw_arrays(p, start, count);
-    p = xgu_end(p);
-    p = pb_end(p);
 }

--- a/samples/triangle/main.c
+++ b/samples/triangle/main.c
@@ -6,6 +6,8 @@
 #include <hal/xbox.h>
 #include <math.h>
 #include <pbkit/pbkit.h>
+#include <xgu/xgu.h>
+#include <xgu/xgux.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,8 +43,6 @@ static const ColoredVertex verts[] = {
 
 static void matrix_viewport(float out[4][4], float x, float y, float width, float height, float z_min, float z_max);
 static void init_shader(void);
-static void set_attrib_pointer(unsigned int index, unsigned int format, unsigned int size, unsigned int stride, const void* data);
-static void draw_arrays(unsigned int mode, int start, int count);
 
 /* Main program function */
 void main(void)
@@ -85,8 +85,8 @@ void main(void)
         pb_target_back_buffer();
 
         /* Clear depth & stencil buffers */
-        pb_erase_depth_stencil_buffer(0, 0, width, height);
-        pb_fill(0, 0, width, height, 0x00000000);
+        pb_erase_depth_stencil_buffer(0, 0, width, height); //FIXME: Do in XGU
+        pb_fill(0, 0, width, height, 0x00000000); //FIXME: Do in XGU
         pb_erase_text_screen();
 
         while(pb_busy()) {
@@ -102,32 +102,30 @@ void main(void)
         p = pb_begin();
 
         /* Set shader constants cursor at C0 */
-        pb_push1(p, NV097_SET_TRANSFORM_CONSTANT_LOAD, 96); p+=2;
+        p = xgu_set_transform_constant_load(p, 96);
 
         /* Send the transformation matrix */
-        pb_push(p++, NV097_SET_TRANSFORM_CONSTANT, 16);
-        memcpy(p, m_viewport, 16*4); p+=16;
+        p = xgu_set_transform_constant(p, m_viewport, 4);
 
         pb_end(p);
         p = pb_begin();
 
         /* Clear all attributes */
-        pb_push(p++, NV097_SET_VERTEX_DATA_ARRAY_FORMAT,16);
         for(i = 0; i < 16; i++) {
-            *(p++) = NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F;
+          p = xgu_set_vertex_data_array_format(p, i, XGU_FLOAT, 0, 0);
         }
         pb_end(p);
 
         /* Set vertex position attribute */
-        set_attrib_pointer(0, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
+        set_attrib_pointer(XGU_VERTEX_ARRAY, XGU_FLOAT,
                            3, sizeof(ColoredVertex), &alloc_vertices[0]);
 
         /* Set vertex diffuse color attribute */
-        set_attrib_pointer(3, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
+        set_attrib_pointer(XGU_COLOR_ARRAY, XGU_FLOAT,
                            3, sizeof(ColoredVertex), &alloc_vertices[3]);
 
         /* Begin drawing triangles */
-        draw_arrays(NV097_SET_BEGIN_END_OP_TRIANGLES, 0, num_vertices);
+        draw_arrays(XGU_TRIANGLES, 0, num_vertices);
 
         /* Draw some text on the screen */
         pb_print("Triangle Demo\n");
@@ -192,27 +190,15 @@ static void init_shader(void)
     p = pb_begin();
 
     /* Set run address of shader */
-    pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_START, 0);
-    p += 2;
+    p = xgu_set_transform_program_start(p, 0);
 
     /* Set execution mode */
-    pb_push1(p, NV097_SET_TRANSFORM_EXECUTION_MODE,
-        MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_MODE, NV097_SET_TRANSFORM_EXECUTION_MODE_MODE_PROGRAM)
-        | MASK(NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE, NV097_SET_TRANSFORM_EXECUTION_MODE_RANGE_MODE_PRIV));
-    p += 2;
-
-    pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_CXT_WRITE_EN, 0);
-    p += 2;
+    p = xgu_set_transform_execution_mode(p, XGU_PROGRAM, XGU_RANGE_MODE_PRIVATE);
+    p = xgu_set_transform_program_cxt_write_enable(p, false);
 
     /* Set cursor and begin copying program */
-    pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_LOAD, 0);
-    p += 2;
-
-    for (i=0; i<sizeof(vs_program)/8; i++) {
-        pb_push(p++, NV097_SET_TRANSFORM_PROGRAM, 4);
-        memcpy(p, &vs_program[i*4], 4*4);
-        p+=4;
-    }
+    p = xgu_set_transform_program_load(p, 0);
+    p = xgu_set_transform_program(p, vs_program, sizeof(vs_program)/16);
 
     pb_end(p);
 
@@ -223,28 +209,20 @@ static void init_shader(void)
 }
 
 /* Set an attribute pointer */
-static void set_attrib_pointer(unsigned int index, unsigned int format, unsigned int size, unsigned int stride, const void* data)
+static void set_attrib_pointer(XguVertexArray index, XguVertexArrayType format, unsigned int size, unsigned int stride, const void* data)
 {
     uint32_t *p = pb_begin();
-    pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_FORMAT + index*4,
-        MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE, format) | \
-        MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_SIZE, size) | \
-        MASK(NV097_SET_VERTEX_DATA_ARRAY_FORMAT_STRIDE, stride));
-    p += 2;
-    pb_push1(p, NV097_SET_VERTEX_DATA_ARRAY_OFFSET + index*4, (uint32_t)data & 0x03ffffff);
-    p += 2;
-    pb_end(p);
+    p = xgu_set_vertex_data_array_format(p, index, format, size, stride);
+    p = xgu_set_vertex_data_array_offset(p, index, (uint32_t)data & 0x03ffffff);
+    p = pb_end(p);
 }
 
 /* Send draw commands for the triangles */
-static void draw_arrays(unsigned int mode, int start, int count)
+static void draw_arrays(XguPrimitiveType mode, int start, int count)
 {
     uint32_t *p = pb_begin();
-    pb_push1(p, NV097_SET_BEGIN_END, mode); p += 2;
-
-    pb_push(p++,0x40000000|NV097_DRAW_ARRAYS,1); //bit 30 means all params go to same register 0x1810
-    *(p++) = MASK(NV097_DRAW_ARRAYS_COUNT, (count-1)) | MASK(NV097_DRAW_ARRAYS_START_INDEX, start);
-
-    pb_push1(p,NV097_SET_BEGIN_END, NV097_SET_BEGIN_END_OP_END); p += 2;
-    pb_end(p);
+    p = xgu_begin(p, mode);
+    p = xgu_draw_arrays(p, start, count);
+    p = xgu_end(p);
+    p = pb_end(p);
 }


### PR DESCRIPTION
*(There's no code yet - this is only a notepad for test-concepts and collecting questions)*

AB and CD allow moving their RGB result `BLUETOALPHA`. There's many possible interpretations of this feature, so this needs a lot of testing.

#### Will RGB still be written?

Test setup:
```c
{
  color {
    spare0.rgb = const(1,0,0,1); // red by default
  }
}
{
  color {
    spare0.a[rgba?] = const(0,1,0,1); // attempt to make RGB green
  }
}
out.rgb = spare0.rgb; // green if RGB is still written; red otherwise
out.a = spare0.a;
```

#### Will ALPHA or RGB be written if both write the same register?

Test setup:
```c
{
  color {
    spare0.a = const(0,1,0,1); // spare0 will be green if bluetoalpha is more important
  }
  alpha {
    spare0.a = const(1,0,0,1); // spare0 will be red if alpha output is more important
  }
}
out.rgb = spare0.rgb;
out.a = spare0.a;
```

#### Will the BLUETOALPHA result from RGB be used as input to ALPHA computation?

Probably not - these are stages (should be conflict free)

Test setup:
```c
{
  alpha {
    spare0.a = const(0, 0, 0, 0); // spare0 alpha is zero by default
  }
}
{
  color {
    spare0.a = const(1,1,1,1); // spare0 alpha will be one if no latency
  }
  alpha {
    spare1.a = spare0.a; // spare1 will get spare0 alpha (new [1] or old [0])
  }
}
out.rgb = spare1.aaa;
out.a = spare1.a;
```

#### Will the ALPHA result be used as input in BLUETOALPHA computation?

Probably not - these are stages (should be conflict free)