### PR TITLE
fp20compiler: Support BLUETOALPHA

### DIFF
--- a/tools/fp20compiler/nvparse_errors.cpp
+++ b/tools/fp20compiler/nvparse_errors.cpp
@@ -29,6 +29,7 @@ void nvparse_errors::reset()
 
 void nvparse_errors::set(const char * e)
 {
+  printf("%s\n", e);
 	if(num_errors < NVPARSE_MAX_ERRORS)
 		elist[num_errors++] = strdup(e);
 }
@@ -36,7 +37,7 @@ void nvparse_errors::set(const char * e)
 void nvparse_errors::set(const char * e, int line_number)
 {
 	char buff[256];
-	sprintf(buff, "error on line %d: %s", line_number, e);
+	printf("error on line %d: %s\n", line_number, e);
 	if(num_errors < NVPARSE_MAX_ERRORS)
 		elist[num_errors++] = strdup(buff);
 }

--- a/tools/fp20compiler/rc1.0_general.cpp
+++ b/tools/fp20compiler/rc1.0_general.cpp
@@ -306,6 +306,17 @@ void GeneralFunctionStruct::Invoke(int stage, int portion, BiasScaleEnum bs)
         printf("    | MASK(NV097_SET_COMBINER_%s_OCW_CD_DOT_ENABLE, %d)\n", portion_s, op[1].op);
     }
 
+    if (portion == RCP_RGB) {
+        //FIXME: Avoid re-use of register in alpha portion?
+        if (op[0].reg[0].reg.bits.channel == RCP_ALPHA) {
+            printf("\n\nBLUETOALPHA_AB\n\n\n");
+        }
+        if (op[1].reg[0].reg.bits.channel == RCP_ALPHA) {
+            printf("\n\nBLUETOALPHA_CD\n\n\n");
+        }
+        assert(op[2].reg[0].reg.bits.channel == RCP_RGB);
+    }
+
     printf("    | MASK(NV097_SET_COMBINER_%s_OCW_OP, NV097_SET_COMBINER_%s_OCW_OP_%s%s)",
             portion_s, portion_s, scale_s,
             (bs.bits.bias == BIAS_BY_NEGATIVE_ONE_HALF) ? "_BIAS" : "");

--- a/tools/fp20compiler/rc1.0_general.cpp
+++ b/tools/fp20compiler/rc1.0_general.cpp
@@ -375,6 +375,13 @@ void OpStruct::Validate(int stage, int portion)
         if (RCP_ALPHA == portion &&
             RCP_RGB == reg[i].reg.bits.channel)
             errors.set("rgb register used in alpha portion");
+        if (i == 0 &&
+            RCP_RGB == portion &&
+            RCP_ALPHA == reg[i].reg.bits.channel)
+            errors.set("alpha register used as output in rgb portion");
+        if (i == 0 &&
+            RCP_BLUE == reg[i].reg.bits.channel)
+            errors.set("blue register used as output");
         if (i > 0 &&
             REG_DISCARD == reg[i].reg.bits.name)
             errors.set("reading from discard");

--- a/tools/fp20compiler/test
+++ b/tools/fp20compiler/test
@@ -1,0 +1,27 @@
+//Foo
+!!TS1.0
+//texture_2d();
+//dot_product_2d_1of2(tex0);
+//dot_product_2d_2of2(tex0);
+
+
+// End of program
+
+
+!!RC1.0
+
+{
+  rgb {
+    spare0.a = col0.rgb * col1.rgb;
+    discard = col0.rgb * col1.rgb;
+    spare1 = sum();
+  }
+  alpha {
+    spare0 = col0.a;
+  }
+}
+
+out.rgb = spare0.rgb;
+out.a = spare0.a;
+
+// End of program


### PR DESCRIPTION
The Xbox GPU allows A/B and C/D color portion results to be saved to alpha. The blue component is used for this.

fp20compiler didn't actually check the output component at all.
I added error checks for the invalid modes, but kept the blue-to-alpha enabled.
I then added support for this in the emitter.

The syntax works like this:

```c
!!RC1.0
{
  rgb {
    //spare0.a = col0.rgb * col1.rgb; // A/B result, would error, as rgb is not allowed in blue to alpha portion
    spare0.a = col0.b * col1.b; // A/B result, writes blue result to alpha
    //spare0.b = col0.b * col1.b; // A/B result, would error as writing b is not allowed
    //spare0 = col0.b * col1.b; // C/D result, would error, as blue is not allowed in rgb portion
    spare0 = col0.rgb * col1.rgb; // C/D result, writes to RGB by default
    //spare1.a = sum(); // AB/CD result, would error, this is not allowed to write to alpha
    spare1.rgb = sum(); // AB/CD result, this is not allowed to write to alpha
  }
  alpha {
    //spare0.rgb = col0.a; // Would error, writing to spare0.rgb or spare0.b is no longer allowed
    //spare0.b = col0.a; // Would error, writing to spare0.rgb or spare0.b is no longer allowed
    //spare0.a = col0.a; // This is fine
    spare0 = col0.a; // Writing to spare0.rgb or spare0.b is no longer allowed
  }
}
out.rgb = spare0.rgb;
out.a = spare0.a;
```

We'll probably have to add code to check conflicts of alpha and color portions.