### PR TITLE
fp20compiler: Annotate shader sections in output

### DIFF
--- a/tools/fp20compiler/main.cpp
+++ b/tools/fp20compiler/main.cpp
@@ -84,6 +84,11 @@ int main(int argc, char** argv) {
     fread(buffer, size, 1, fh);
     buffer[size] = '\0';
 
+    if (strchr(buffer, '\r') != NULL) {
+        fprintf(stderr, "found unsupported line-endings\n");
+        exit(1);
+    }
+
     translate(buffer);
 
     fclose(fh);


### PR DESCRIPTION
Failed in upstream 115 (which it is also based on).

This fails with `\r\n` line-endings.
When disabling those, this didn't pass CI because Windows cgc probably emits them.