### PR TITLE
fp20compiler: Rework color grammar

### DIFF
--- a/tools/fp20compiler/rc1.0_combiners.cpp
+++ b/tools/fp20compiler/rc1.0_combiners.cpp
@@ -28,14 +28,17 @@ void CombinersStruct::Invoke()
     //     glCombinerParameterfvNV(cc[i].reg.bits.name, &(cc[i].v[0]));
         const char* general_cmd = NULL;
         const char* final_cmd = NULL;
+        int localConstCount = 0;
         switch(ccs.cc[i].reg.bits.name) {
         case REG_CONSTANT_COLOR0:
             general_cmd = "NV097_SET_COMBINER_FACTOR0";
             final_cmd = "NV097_SET_SPECULAR_FOG_FACTOR + 0";
+            localConstCount = generals.localConst0Count;
             break;
         case REG_CONSTANT_COLOR1:
             general_cmd = "NV097_SET_COMBINER_FACTOR1";
             final_cmd = "NV097_SET_SPECULAR_FOG_FACTOR + 4";
+            localConstCount = generals.localConst1Count;
             break;
         default:
             assert(false);
@@ -50,7 +53,7 @@ void CombinersStruct::Invoke()
         //   will emit its own constants (for FACTOR#_EACH_STAGE).
         // Also see mode selection in GeneralCombinersStruct::Invoke() and
         // local-constant emitter in GeneralCombinerStruct::Invoke(int stage).
-        if (generals.localConsts == 0) {
+        if (localConstCount == 0) {
             printf("pb_push1(p, %s,", general_cmd);
             printf("\n    MASK(0xFF000000, 0x%02X)", (unsigned char)(ccs.cc[i].v[3] * 0xFF));
             printf("\n    | MASK(0x00FF0000, 0x%02X)", (unsigned char)(ccs.cc[i].v[0] * 0xFF));

--- a/tools/fp20compiler/rc1.0_combiners.h
+++ b/tools/fp20compiler/rc1.0_combiners.h
@@ -6,19 +6,14 @@
 
 class CombinersStruct {
 public:
-    void Init(GeneralCombinersStruct _gcs, FinalCombinerStruct _fc, ConstColorStruct _cc0, ConstColorStruct _cc1)
-    { generals = _gcs; final = _fc; cc[0] = _cc0; cc[1] = _cc1; numConsts = 2;}
-    void Init(GeneralCombinersStruct _gcs, FinalCombinerStruct _fc, ConstColorStruct _cc0)
-    { generals = _gcs; final = _fc; cc[0] = _cc0; numConsts = 1;}
-    void Init(GeneralCombinersStruct _gcs, FinalCombinerStruct _fc)
-    { generals = _gcs; final = _fc; numConsts = 0;}
+    void Init(GeneralCombinersStruct _gcs, FinalCombinerStruct _fc, ConstColorsStruct _ccs)
+    { generals = _gcs; final = _fc; ccs = _ccs;}
     void Validate();
     void Invoke();
 private:
     GeneralCombinersStruct generals;
     FinalCombinerStruct final;
-    ConstColorStruct cc[2];
-    int numConsts;
+    ConstColorsStruct ccs;
 };
 
 #endif

--- a/tools/fp20compiler/rc1.0_general.cpp
+++ b/tools/fp20compiler/rc1.0_general.cpp
@@ -7,7 +7,7 @@
 #include <cstdio>
 #include <cassert>
 
-void GeneralCombinersStruct::Validate(int numConsts, ConstColorStruct *pcc)
+void GeneralCombinersStruct::Validate(ConstColorsStruct *ccs)
 {
     // GLint maxGCs;
     // glGetIntegerv(GL_MAX_GENERAL_COMBINERS_NV, &maxGCs);
@@ -25,23 +25,24 @@ void GeneralCombinersStruct::Validate(int numConsts, ConstColorStruct *pcc)
         num = 1;
     }
 
-    localConsts = 0;
     int i;
-    for (i = 0; i < num; i++) {
+    for (i = 0; i < num; i++)
         general[i].Validate(i);
-        localConsts += general[i].numConsts;
-    }
+    for (; i < maxGCs; i++)
+        general[i].ZeroOut();
+
+    localConsts = 0;
+    for (i = 0; i < num; i++)
+        localConsts += general[i].ccs.numConsts;
 
     if (localConsts > 0)
         // if (NULL == glCombinerStageParameterfvNV)
         //     errors.set("local constant(s) specified, but not supported -- ignored");
         // else
         for (i = 0; i < num; i++)
-            general[i].SetUnusedLocalConsts(numConsts, pcc);
+            general[i].ccs.SetUnusedConsts(ccs);
 
 
-    for (; i < maxGCs; i++)
-        general[i].ZeroOut();
 }
 
 void GeneralCombinersStruct::Invoke()
@@ -75,7 +76,7 @@ void GeneralCombinersStruct::Invoke()
 void GeneralCombinerStruct::ZeroOut()
 {
         numPortions = 2;
-        numConsts = 0;
+        ccs.numConsts = 0;
 
         portion[0].ZeroOut();
         portion[0].designator = RCP_RGB;
@@ -84,30 +85,43 @@ void GeneralCombinerStruct::ZeroOut()
 }
 
 
-void GeneralCombinerStruct::SetUnusedLocalConsts(int numGlobalConsts, ConstColorStruct *globalCCs)
+void ConstColorsStruct::SetUnusedConsts(ConstColorsStruct *ccs)
 {
-        int i;
-    for (i = 0; i < numGlobalConsts; i++) {
+    int i;
+    for (i = 0; i < ccs->numConsts; i++) {
         bool constUsed = false;
         int j;
         for (j = 0; j < numConsts; j++)
-            constUsed |= (cc[j].reg.bits.name == globalCCs[i].reg.bits.name);
+            constUsed |= (cc[j].reg.bits.name == ccs->cc[i].reg.bits.name);
         if (!constUsed) {
             assert(numConsts < 2);
-            cc[numConsts++] = globalCCs[i];
+            cc[numConsts++] = ccs->cc[i];
         }
+    }
+}
+
+void ConstColorsStruct::Validate() {
+    int i;
+    for (i = 0; i < numConsts; i++) {
+        int j;
+        for (j = 0; j < 4; j++)
+            if(cc[i].v[j] < 0.0f || cc[i].v[j] > 1.0f)
+                errors.set("value out of range", cc[i].line_number);
+    }
+
+    if (2 == numConsts && cc[0].reg.bits.name == cc[1].reg.bits.name) {
+        errors.set("constant set twice", cc[1].line_number);
+
+        // Only use the one that was set last
+        cc[0] = cc[1];
+        numConsts = 1;
     }
 }
 
 
 void GeneralCombinerStruct::Validate(int stage)
 {
-    if (2 == numConsts &&
-        cc[0].reg.bits.name == cc[1].reg.bits.name) {
-        errors.set("local constant set twice", cc[1].line_number);
-        cc[0] = cc[1];
-        numConsts = 1;
-    }
+    ccs.Validate();
 
     switch (numPortions)
     {
@@ -138,10 +152,10 @@ void GeneralCombinerStruct::Invoke(int stage)
     // if (NULL != glCombinerStageParameterfvNV)
     //     for (i = 0; i < numConsts; i++)
     //         glCombinerStageParameterfvNV(GL_COMBINER0_NV + stage, cc[i].reg.bits.name, &(cc[i].v[0]));
-    assert(numConsts <= 2);
-    for (i = 0; i < numConsts; i++) {
+    assert(ccs.numConsts <= 2);
+    for (i = 0; i < ccs.numConsts; i++) {
         const char* cmd = NULL;
-        switch(cc[i].reg.bits.name) {
+        switch(ccs.cc[i].reg.bits.name) {
         case REG_CONSTANT_COLOR0:
             cmd = "NV097_SET_COMBINER_FACTOR0";
             break;
@@ -153,16 +167,11 @@ void GeneralCombinerStruct::Invoke(int stage)
             break;
         }
 
-        assert(cc[i].v[0] >= 0.0f && cc[i].v[0] <= 1.0f);
-        assert(cc[i].v[1] >= 0.0f && cc[i].v[1] <= 1.0f);
-        assert(cc[i].v[2] >= 0.0f && cc[i].v[2] <= 1.0f);
-        assert(cc[i].v[3] >= 0.0f && cc[i].v[3] <= 1.0f);
-
         printf("pb_push1(p, %s + %d * 4,", cmd, stage);
-        printf("\n    MASK(0xFF000000, 0x%02X)", (unsigned char)(cc[i].v[3] * 0xFF));
-        printf("\n    | MASK(0x00FF0000, 0x%02X)", (unsigned char)(cc[i].v[0] * 0xFF));
-        printf("\n    | MASK(0x0000FF00, 0x%02X)", (unsigned char)(cc[i].v[1] * 0xFF));
-        printf("\n    | MASK(0x000000FF, 0x%02X)", (unsigned char)(cc[i].v[2] * 0xFF));
+        printf("\n    MASK(0xFF000000, 0x%02X)", (unsigned char)(ccs.cc[i].v[3] * 0xFF));
+        printf("\n    | MASK(0x00FF0000, 0x%02X)", (unsigned char)(ccs.cc[i].v[0] * 0xFF));
+        printf("\n    | MASK(0x0000FF00, 0x%02X)", (unsigned char)(ccs.cc[i].v[1] * 0xFF));
+        printf("\n    | MASK(0x000000FF, 0x%02X)", (unsigned char)(ccs.cc[i].v[2] * 0xFF));
         printf(");\n");
         printf("p += 2;\n");
     }

--- a/tools/fp20compiler/rc1.0_general.h
+++ b/tools/fp20compiler/rc1.0_general.h
@@ -21,6 +21,20 @@ public:
     float v[4];
 };
 
+class ConstColorsStruct {
+public:
+    void Init(ConstColorStruct _cc0, ConstColorStruct _cc1)
+    { cc[0] = _cc0; cc[1] = _cc1; numConsts = 2; }
+    void Init(ConstColorStruct _cc0)
+    { cc[0] = _cc0; numConsts = 1; }
+    void Init()
+    { numConsts = 0; }
+    void Validate();
+    void SetUnusedConsts(ConstColorsStruct *ccs);
+    ConstColorStruct cc[2];
+    int numConsts;
+};
+
 class OpStruct {
 public:
     void Init(int _op, RegisterEnum _reg0, MappedRegisterStruct _reg1, MappedRegisterStruct _reg2)
@@ -61,28 +75,18 @@ public:
 
 class GeneralCombinerStruct {
 public:
-    void Init(GeneralPortionStruct _portion0, GeneralPortionStruct _portion1, ConstColorStruct _cc0, ConstColorStruct _cc1)
-    { portion[0] = _portion0; portion[1] = _portion1; numPortions = 2; cc[0] = _cc0; cc[1] = _cc1; numConsts = 2; }
-    void Init(GeneralPortionStruct _portion0, GeneralPortionStruct _portion1, ConstColorStruct _cc0)
-    { portion[0] = _portion0; portion[1] = _portion1; numPortions = 2; cc[0] = _cc0; numConsts = 1; }
-    void Init(GeneralPortionStruct _portion0, GeneralPortionStruct _portion1)
-    { portion[0] = _portion0; portion[1] = _portion1; numPortions = 2; numConsts = 0; }
+    void Init(GeneralPortionStruct _portion0, GeneralPortionStruct _portion1, ConstColorsStruct _ccs)
+    { portion[0] = _portion0; portion[1] = _portion1; numPortions = 2; ccs = _ccs; }
 
-    void Init(GeneralPortionStruct _portion0, ConstColorStruct _cc0, ConstColorStruct _cc1)
-    { portion[0] = _portion0; numPortions = 1; cc[0] = _cc0; cc[1] = _cc1; numConsts = 2; }
-    void Init(GeneralPortionStruct _portion0, ConstColorStruct _cc0)
-    { portion[0] = _portion0; numPortions = 1; cc[0] = _cc0; numConsts = 1; }
-    void Init(GeneralPortionStruct _portion0)
-    { portion[0] = _portion0; numPortions = 1; numConsts = 0; }
+    void Init(GeneralPortionStruct _portion0, ConstColorsStruct _ccs)
+    { portion[0] = _portion0; numPortions = 1; ccs = _ccs; }
 
     void Validate(int stage);
-    void SetUnusedLocalConsts(int numGlobalConsts, ConstColorStruct *globalCCs);
     void Invoke(int stage);
     void ZeroOut();
     GeneralPortionStruct portion[2];
     int numPortions;
-    ConstColorStruct cc[2];
-    int numConsts;
+    ConstColorsStruct ccs;
 };
 
 class GeneralCombinersStruct {
@@ -97,7 +101,7 @@ public:
             errors.set("too many general-combiners", ::line_number);
         return *this;
     }
-    void Validate(int numConsts, ConstColorStruct *cc);
+    void Validate(ConstColorsStruct *ccs);
     void Invoke();
     GeneralCombinerStruct general[RCP_NUM_GENERAL_COMBINERS];
     int num;

--- a/tools/fp20compiler/rc1.0_general.h
+++ b/tools/fp20compiler/rc1.0_general.h
@@ -30,7 +30,8 @@ public:
     void Init()
     { numConsts = 0; }
     void Validate();
-    void SetUnusedConsts(ConstColorsStruct *ccs);
+    int Count(int reg_name);
+    void SetUnusedConst(int reg_name, ConstColorsStruct *ccs);
     ConstColorStruct cc[2];
     int numConsts;
 };
@@ -105,7 +106,8 @@ public:
     void Invoke();
     GeneralCombinerStruct general[RCP_NUM_GENERAL_COMBINERS];
     int num;
-    int localConsts;
+    int localConst0Count;
+    int localConst1Count;
 };
 
 

--- a/tools/fp20compiler/rc1.0_grammar.y
+++ b/tools/fp20compiler/rc1.0_grammar.y
@@ -23,6 +23,7 @@ int yylex ( void );
   BiasScaleEnum biasScaleEnum;
   MappedRegisterStruct mappedRegisterStruct;
   ConstColorStruct constColorStruct;
+  ConstColorsStruct constColorsStruct;
   GeneralPortionStruct generalPortionStruct;
   GeneralFunctionStruct generalFunctionStruct;
   OpStruct opStruct;
@@ -51,6 +52,7 @@ int yylex ( void );
 %type <combinersStruct> WholeEnchilada Combiners
 
 %type <constColorStruct> ConstColor
+%type <constColorsStruct> ConstColors
 %type <generalCombinerStruct> GeneralCombiner
 %type <generalCombinersStruct> GeneralCombiners
 %type <ival> PortionDesignator
@@ -76,46 +78,18 @@ WholeEnchilada	: Combiners
 		}
 		;
 
-Combiners : ConstColor GeneralCombiners FinalCombiner
+Combiners : ConstColors GeneralCombiners FinalCombiner
 		{
 			CombinersStruct combinersStruct;
 			combinersStruct.Init($2, $3, $1);
 			$$ = combinersStruct;
 		}
-		| ConstColor ConstColor GeneralCombiners FinalCombiner
-		{
-			CombinersStruct combinersStruct;
-			combinersStruct.Init($3, $4, $1, $2);
-			$$ = combinersStruct;
-		}
-		| GeneralCombiners FinalCombiner
-		{
-			CombinersStruct combinersStruct;
-			combinersStruct.Init($1, $2);
-			$$ = combinersStruct;
-		}
-		| ConstColor FinalCombiner
+		| ConstColors FinalCombiner
 		{
 			GeneralCombinersStruct generalCombinersStruct;
 			generalCombinersStruct.Init();
 			CombinersStruct combinersStruct;
 			combinersStruct.Init(generalCombinersStruct, $2, $1);
-			$$ = combinersStruct;
-		}
-		| ConstColor ConstColor FinalCombiner
-		{
-			GeneralCombinersStruct generalCombinersStruct;
-			generalCombinersStruct.Init();
-			CombinersStruct combinersStruct;
-			combinersStruct.Init(generalCombinersStruct, $3, $1, $2);
-			$$ = combinersStruct;
-		}
-		| FinalCombiner
-		{
-			GeneralCombinersStruct generalCombinersStruct;
-			generalCombinersStruct.Init();
-			CombinersStruct combinersStruct;
-			combinersStruct.Init(generalCombinersStruct, $1);
 			$$ = combinersStruct;
 		}
 		;
@@ -125,6 +99,27 @@ ConstColor : constVariable equals openParen floatValue comma floatValue comma fl
 			ConstColorStruct constColorStruct;
 			constColorStruct.Init($1, $4, $6, $8, $10);
 			$$ = constColorStruct;
+		}
+		;
+
+
+ConstColors : ConstColor ConstColor
+		{
+			ConstColorsStruct constColorsStruct;
+			constColorsStruct.Init($1, $2);
+			$$ = constColorsStruct;
+		}
+		| ConstColor
+		{
+			ConstColorsStruct constColorsStruct;
+			constColorsStruct.Init($1);
+			$$ = constColorsStruct;
+		}
+		| /* empty */
+		{
+			ConstColorsStruct constColorsStruct;
+			constColorsStruct.Init();
+			$$ = constColorsStruct;
 		}
 		;
  
@@ -142,40 +137,16 @@ GeneralCombiners	 : GeneralCombiners GeneralCombiner
 		}
 		;
  
-GeneralCombiner : openBracket GeneralPortion GeneralPortion closeBracket
-		{
-			GeneralCombinerStruct generalCombinerStruct;
-			generalCombinerStruct.Init($2, $3);
-			$$ = generalCombinerStruct;
-		}
-		| openBracket ConstColor GeneralPortion GeneralPortion closeBracket
+GeneralCombiner : openBracket ConstColors GeneralPortion GeneralPortion closeBracket
 		{
 			GeneralCombinerStruct generalCombinerStruct;
 			generalCombinerStruct.Init($3, $4, $2);
 			$$ = generalCombinerStruct;
 		}
-		| openBracket ConstColor ConstColor GeneralPortion GeneralPortion closeBracket
-		{
-			GeneralCombinerStruct generalCombinerStruct;
-			generalCombinerStruct.Init($4, $5, $2, $3);
-			$$ = generalCombinerStruct;
-		}
-		| openBracket GeneralPortion closeBracket
-		{
-			GeneralCombinerStruct generalCombinerStruct;
-			generalCombinerStruct.Init($2);
-			$$ = generalCombinerStruct;
-		}
-		| openBracket ConstColor GeneralPortion closeBracket
+		| openBracket ConstColors GeneralPortion closeBracket
 		{
 			GeneralCombinerStruct generalCombinerStruct;
 			generalCombinerStruct.Init($3, $2);
-			$$ = generalCombinerStruct;
-		}
-		| openBracket ConstColor ConstColor GeneralPortion closeBracket
-		{
-			GeneralCombinerStruct generalCombinerStruct;
-			generalCombinerStruct.Init($4, $2, $3);
 			$$ = generalCombinerStruct;
 		}
 		;


### PR DESCRIPTION
The first commit refactors our grammar rules, so that constant colors are combined.
The old grammar was like this (where `Foo` is a placeholder typename):

* `Foo` = For Foo without color
* `ConstColor Foo` = For Foo with 1 color
* `ConstColor ConstColor Foo` = For Foo with 2 colors

The new gammar rule is:

* `ConstColors Foo` = For Foo with 0, 1 or 2 colors (contained in `ConstColors`)

This new grammar makes error handling more consistent. An assert from the old-code, which handled out-of-range colors, has been replaced by a new error message.
The new implementation also simplifies how we inherent colors from global scope into local scopes.
Most of the constant-color related code has been moved into a new `ConstColorsStruct` class.

---

The second commit allows different SAME / EACH modes for const0 and const1.
This change closes upstream issue \<FIXME\>