### PR TITLE
Add nxdk-rdt as library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,9 @@
 [submodule "lib/sdl/SDL_ttf"]
 	path = lib/sdl/SDL_ttf
 	url = https://github.com/SDL-mirror/SDL_ttf
+[submodule "lib/nxdk-rdt"]
+	path = lib/nxdk-rdt/nxdk-rdt
+	url = https://github.com/XboxDev/nxdk-rdt.git
+[submodule "lib/nxdk-rdt/nxdk-rdt"]
+	path = lib/nxdk-rdt/nxdk-rdt
+	url = https://github.com/XboxDev/nxdk-rdt.git

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,11 @@ include $(NXDK_DIR)/lib/sdl/SDL2/Makefile.xbox
 include $(NXDK_DIR)/lib/sdl/Makefile
 endif
 
+ifneq ($(NXDK_RDT),)
+include $(NXDK_DIR)/lib/nxdk-rdt/Makefile
+endif
+
+
 V = 0
 VE_0 := @
 VE_1 :=

--- a/lib/nxdk-rdt/Makefile
+++ b/lib/nxdk-rdt/Makefile
@@ -1,0 +1,16 @@
+NXDK_RDT_DIR = $(NXDK_DIR)/lib/nxdk-rdt/nxdk-rdt
+NXDK_RDT_SRCS += $(NXDK_RDT_DIR)/dbgd.c
+NXDK_RDT_SRCS += $(NXDK_RDT_DIR)/net.c
+NXDK_RDT_SRCS += $(NXDK_RDT_DIR)/../library.c
+NXDK_RDT_OBJS = $(addsuffix .obj, $(basename $(NXDK_RDT_SRCS)))
+
+$(NXDK_DIR)/lib/libnxdk-rdt.lib: $(NXDK_RDT_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libnxdk-rdt.lib
+
+CLEANRULES += clean-nxdk-rdt
+
+.PHONY: clean-nxdk-rdt
+clean-nxdk-rdt:
+	$(VE)rm -f $(NXDK_RDT_OBJS) \
+	           $(NXDK_DIR)/lib/libnxdk-rdt.lib

--- a/lib/nxdk-rdt/library.c
+++ b/lib/nxdk-rdt/library.c
@@ -1,0 +1,6 @@
+__attribute__((constructor))
+void initialize_nxdk_rdt(void) {
+    // Set up threads for nxdk-rdt
+    net_init();
+    dbgd_init();
+}

--- a/samples/nxdk-rdt/Makefile
+++ b/samples/nxdk-rdt/Makefile
@@ -1,0 +1,8 @@
+XBE_TITLE=nxdk-rdt
+GEN_XISO = $(XBE_TITLE).iso
+SRCS = $(wildcard $(CURDIR)/*.c)
+NXDK_DIR = $(CURDIR)/../..
+
+NXDK_RDT=y
+
+include $(NXDK_DIR)/Makefile

--- a/samples/nxdk-rdt/main.c
+++ b/samples/nxdk-rdt/main.c
@@ -1,0 +1,15 @@
+#include <hal/debug.h>
+#include <hal/video.h>
+#include <windows.h>
+
+int main(void)
+{
+    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+
+    while(1) {
+        debugPrint("Hello NXDK-RDT!\n");
+        Sleep(2000);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
FIXME:
- PR description
- Needs update to current nxdk-rdt PR
- Test
- Get rid of debug printing
- Add API or something so that networked applications also still work with nxdk-rdt (might be enough to split net.c away)
- Integrate the nxdk-rdt makefile into our make system, so that the protobuf stuff will be build
- Submodules are messed up (as usual..)