### PR TITLE
fp20compiler: Split constant-color emitter into separate function

### DIFF
--- a/tools/fp20compiler/rc1.0_combiners.cpp
+++ b/tools/fp20compiler/rc1.0_combiners.cpp
@@ -19,6 +19,23 @@ void CombinersStruct::Validate()
     final.Validate();
 }
 
+static void PrintColorSetter(const char* cmd, const ConstColorStruct& cc) {
+    //FIXME: Move to ConstColorStruct::Validate?
+    assert(cc.v[0] >= 0.0f && cc.v[0] <= 1.0f);
+    assert(cc.v[1] >= 0.0f && cc.v[1] <= 1.0f);
+    assert(cc.v[2] >= 0.0f && cc.v[2] <= 1.0f);
+    assert(cc.v[3] >= 0.0f && cc.v[3] <= 1.0f);
+
+    //FIXME: Move to ConstColorStruct::Invoke(bool isFinal)?
+    printf("pb_push1(p, %s,", cmd);
+    printf("\n    MASK(0xFF000000, 0x%02X)", (unsigned char)(cc.v[3] * 0xFF));
+    printf("\n    | MASK(0x00FF0000, 0x%02X)", (unsigned char)(cc.v[0] * 0xFF));
+    printf("\n    | MASK(0x0000FF00, 0x%02X)", (unsigned char)(cc.v[1] * 0xFF));
+    printf("\n    | MASK(0x000000FF, 0x%02X)", (unsigned char)(cc.v[2] * 0xFF));
+    printf(");\n");
+    printf("p += 2;\n");
+}
+
 void CombinersStruct::Invoke()
 {
     assert(numConsts <= 2);
@@ -40,11 +57,6 @@ void CombinersStruct::Invoke()
             break;
         }
 
-        assert(cc[i].v[0] >= 0.0f && cc[i].v[0] <= 1.0f);
-        assert(cc[i].v[1] >= 0.0f && cc[i].v[1] <= 1.0f);
-        assert(cc[i].v[2] >= 0.0f && cc[i].v[2] <= 1.0f);
-        assert(cc[i].v[3] >= 0.0f && cc[i].v[3] <= 1.0f);
-
         // - If no local-constants are used, the general-combiners only use
         //   global-constants (so we use FACTOR#_SAME_FACTOR_ALL).
         //   NV2A takes those from the first stage, which we emit here.
@@ -54,23 +66,11 @@ void CombinersStruct::Invoke()
         // Also see mode selection in GeneralCombinersStruct::Invoke() and
         // local-constant emitter in GeneralCombinerStruct::Invoke(int stage).
         if (generals.localConsts == 0) {
-            printf("pb_push1(p, %s,", general_cmd);
-            printf("\n    MASK(0xFF000000, 0x%02X)", (unsigned char)(cc[i].v[3] * 0xFF));
-            printf("\n    | MASK(0x00FF0000, 0x%02X)", (unsigned char)(cc[i].v[0] * 0xFF));
-            printf("\n    | MASK(0x0000FF00, 0x%02X)", (unsigned char)(cc[i].v[1] * 0xFF));
-            printf("\n    | MASK(0x000000FF, 0x%02X)", (unsigned char)(cc[i].v[2] * 0xFF));
-            printf(");\n");
-            printf("p += 2;\n");
+            PrintColorSetter(general_cmd, cc[i]);
         }
 
         // Global-constants are also used in final-combiner
-        printf("pb_push1(p, %s,", final_cmd);
-        printf("\n    MASK(0xFF000000, 0x%02X)", (unsigned char)(cc[i].v[3] * 0xFF));
-        printf("\n    | MASK(0x00FF0000, 0x%02X)", (unsigned char)(cc[i].v[0] * 0xFF));
-        printf("\n    | MASK(0x0000FF00, 0x%02X)", (unsigned char)(cc[i].v[1] * 0xFF));
-        printf("\n    | MASK(0x000000FF, 0x%02X)", (unsigned char)(cc[i].v[2] * 0xFF));
-        printf(");\n");
-        printf("p += 2;\n");
+        PrintColorSetter(final_cmd, cc[i]);
     }
 
 

--- a/tools/fp20compiler/rc1.0_general.h
+++ b/tools/fp20compiler/rc1.0_general.h
@@ -16,6 +16,8 @@ class ConstColorStruct {
 public:
     void Init(RegisterEnum _reg, float _v0, float _v1, float _v2, float _v3)
     { reg = _reg; v[0] = _v0; v[1] = _v1; v[2] = _v2; v[3] = _v3; }
+    void Validate();
+    void Invoke();
     RegisterEnum reg;
     float v[4];
 };


### PR DESCRIPTION
This might be suitable for #43 or something. Maybe also upstream, but I didn't want to do it as I don't know in which file this code will end up in (and what constraints it will have to respect for the EACH/SAME stuff).