### PR TITLE
cxbe: Add cdxt tool

### DIFF
--- a/tools/cxbe/.gitignore
+++ b/tools/cxbe/.gitignore
@@ -1,1 +1,2 @@
 cxbe
+cdxt

--- a/tools/cxbe/Cdxt.cpp
+++ b/tools/cxbe/Cdxt.cpp
@@ -1,0 +1,97 @@
+// Licensed under GPLv2 or (at your option) any later version.
+// Copyright (C) 2020 Jannik Vogel
+
+#include "Exe.h"
+#include "Common.h"
+
+#include <string.h>
+#include <stdio.h>
+
+// program entry point
+int main(int argc, char *argv[])
+{
+    char szErrorMessage[ERROR_LEN+1] = {0};
+    char szExeFilename[OPTION_LEN+1] = {0};
+    char szDxtFilename[OPTION_LEN+1] = {0};
+
+    const char* program = argv[0];
+    const char* program_desc = "CDXT: EXE to DXT Relinker";
+    static Option options[] = {
+        { szExeFilename, NULL,  "exefile"  },
+        { szDxtFilename, "OUT", "filename" },
+        { NULL }
+    };
+
+    if(ParseOptions(argv, argc, options, szErrorMessage)) {
+        goto cleanup;
+    }
+
+    // verify we recieved the required parameters
+    if(szExeFilename[0] == '\0')
+    {
+        ShowUsage(program, program_desc, options);
+        return 1;
+    }
+
+    // if we don't have an Dxt filename, generate one from szExeFilename
+    if(szDxtFilename[0] == '\0')
+    {
+        GenerateFilename(szDxtFilename, ".dxt", szExeFilename, ".exe");
+    }
+
+    // open and convert Exe file
+    {
+        Exe *ExeFile = new Exe(szExeFilename);
+
+        if(ExeFile->GetError() != 0)
+        {
+            strncpy(szErrorMessage, ExeFile->GetError(), ERROR_LEN);
+            goto cleanup;
+        }
+
+        // Set up subsystem (will be ignored)
+        ExeFile->m_OptionalHeader.m_subsystem_version_major = 1;
+        ExeFile->m_OptionalHeader.m_subsystem_version_minor = 0;
+        ExeFile->m_OptionalHeader.m_subsystem = IMAGE_SUBSYSTEM_XBOX;
+
+        // Set up alignments (DXTs typically use 32 byte alignments)
+        //FIXME: Report error if FileAlignment > SectionAlignment
+        ExeFile->m_OptionalHeader.m_file_alignment =
+            ExeFile->m_OptionalHeader.m_section_alignment;
+
+        // DXTs are EXE files, which are in-memory images.
+        // The loader in XBDM.dll loads the file into one large memory area.
+        // It does not load section-by-section and will ignore where the
+        // section should be loaded at.
+        // Therefore the raw and virtual address must match.
+        // If our DXT do not respect this, the DXT loader will crash during
+        // relocation (using .reloc) when trying to access sections.
+        for(uint32 v=0;v<ExeFile->m_Header.m_sections;v++)
+        {
+            ExeFile->m_SectionHeader[v].m_raw_addr =
+                ExeFile->m_SectionHeader[v].m_virtual_addr;
+        }
+
+        ExeFile->Export(szDxtFilename);
+
+        if(ExeFile->GetError() != 0)
+        {
+            strncpy(szErrorMessage, ExeFile->GetError(), ERROR_LEN);
+            goto cleanup;
+        }
+    }
+
+cleanup:
+
+    if(szErrorMessage[0] != 0)
+    {
+        ShowUsage(program, program_desc, options);
+    
+        printf("\n");
+        printf(" *  Error : %s\n", szErrorMessage);
+
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/cxbe/Cxbe.cpp
+++ b/tools/cxbe/Cxbe.cpp
@@ -1,36 +1,6 @@
-// ******************************************************************
-// *
-// *    .,-:::::    .,::      .::::::::.    .,::      .:
-// *  ,;;;'````'    `;;;,  .,;;  ;;;'';;'   `;;;,  .,;; 
-// *  [[[             '[[,,[['   [[[__[[\.    '[[,,[['  
-// *  $$$              Y$$$P     $$""""Y$$     Y$$$P    
-// *  `88bo,__,o,    oP"``"Yo,  _88o,,od8P   oP"``"Yo,  
-// *    "YUMMMMMP",m"       "Mm,""YUMMMP" ,m"       "Mm,
-// *
-// *   Cxbx->Standard->Cxbe->Main.cpp
-// *
-// *  This file is part of the Cxbx project.
-// *
-// *  Cxbx and Cxbe are free software; you can redistribute them
-// *  and/or modify them under the terms of the GNU General Public
-// *  License as published by the Free Software Foundation; either
-// *  version 2 of the license, or (at your option) any later version.
-// *
-// *  This program is distributed in the hope that it will be useful,
-// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
-// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// *  GNU General Public License for more details.
-// *
-// *  You should have recieved a copy of the GNU General Public License
-// *  along with this program; see the file COPYING.
-// *  If not, write to the Free Software Foundation, Inc.,
-// *  59 Temple Place - Suite 330, Bostom, MA 02111-1307, USA.
-// *
-// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
-// *
-// *  All rights reserved
-// *
-// ******************************************************************
+// Licensed under GPLv2 or (at your option) any later version.
+// Copyright (C) 2002-2003 Aaron Robinson <caustik@caustik.com>
+
 #include "Exe.h"
 #include "Xbe.h"
 #include "Common.h"

--- a/tools/cxbe/Exe.h
+++ b/tools/cxbe/Exe.h
@@ -209,6 +209,7 @@ class Exe : public Error
 #define IMAGE_SUBSYSTEM_POSIX_CUI            7
 #define IMAGE_SUBSYSTEM_NATIVE_WINDOWS       8
 #define IMAGE_SUBSYSTEM_WINDOWS_CE_GUI       9
+#define IMAGE_SUBSYSTEM_XBOX                14
 
 // directory entries
 #define IMAGE_DIRECTORY_ENTRY_EXPORT          0   // Export Directory

--- a/tools/cxbe/Makefile
+++ b/tools/cxbe/Makefile
@@ -1,9 +1,24 @@
-INCLUDES := $(wildcard *.h)
-SRCS := $(wildcard *.cpp)
+INCLUDES := \
+  Common.h \
+  Cxbx.h \
+  Error.h \
+  Exe.h \
+  Xbe.h
+SRCS := \
+  Common.cpp \
+  Error.cpp \
+  Exe.cpp \
+  OpenXDK.cpp \
+  Xbe.cpp
 
-cxbe: $(SRCS) $(INCLUDES)
-	$(CXX) -o '$@' $(SRCS)
+all: cxbe cdxt
+
+cxbe: Cxbe.cpp $(SRCS) $(INCLUDES)
+	$(CXX) -o '$@' $^
+
+cdxt: Cdxt.cpp $(SRCS) $(INCLUDES)
+	$(CXX) -o '$@' $^
 
 .PHONY: clean
 clean:
-	rm -f cxbe
+	rm -f cxbe cdxt

--- a/tools/cxbe/Makefile.am
+++ b/tools/cxbe/Makefile.am
@@ -1,8 +1,0 @@
-CXX=g++
-EXEEXT=$(XDKEXEEXT)
-
-bin_PROGRAMS = cxbe
-cxbe_SOURCES = $(SRCS)
-
-SRCS = Error.cpp Exe.cpp Main.cpp OpenXDK.cpp Xbe.cpp
-


### PR DESCRIPTION
This splits cxbe into 2 tools:

1. The previously known cxbe (EXE &rarr; XBE)
2. The newly added cdxt (EXE &rarr; DXT)

cdxt was separated from the cxbe tool because DXT files are just memory images of DLLs (unlike XBEs which are an entirely new format); we'll want vey different command line options to reflect this.

Because we already had a PE parser and relocation code in cxbe, it still makes sense to reuse that codebase.

Testing is a bit complicated: This PR does not add any makefile or useful libraries, so there is no practical use for cdxt yet.
However, you can test it using https://github.com/JayFoxRox/nxdk/pull/10 which is based on this branch.

FIXME:
- testing