### PR TITLE
build: Don't add lib/hal as include directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,13 @@ EXTRACT_XISO = $(NXDK_DIR)/tools/extract-xiso/build/extract-xiso
 TOOLS        = cxbe vp20compiler fp20compiler extract-xiso
 NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -ffreestanding -nostdlib -fno-builtin -fno-exceptions \
-               -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt/libc_extensions \
-               -I$(NXDK_DIR)/lib/hal \
-               -isystem $(NXDK_DIR)/lib/pdclib/include \
-               -I$(NXDK_DIR)/lib/pdclib/platform/xbox/include \
-               -I$(NXDK_DIR)/lib/winapi \
-               -I$(NXDK_DIR)/lib/xboxrt/vcruntime \
+               -isystem$(NXDK_DIR)/lib \
+               -isystem$(NXDK_DIR)/lib/xboxrt/libc_extensions \
+               -isystem$(NXDK_DIR)/lib/hal \
+               -isystem$(NXDK_DIR)/lib/pdclib/include \
+               -isystem$(NXDK_DIR)/lib/pdclib/platform/xbox/include \
+               -isystem$(NXDK_DIR)/lib/winapi \
+               -isystem$(NXDK_DIR)/lib/xboxrt/vcruntime \
                -Wno-ignored-attributes -DNXDK -D__STDC__=1
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -ffreestanding -nostdlib -fno-builtin -fno-exceptions \
                -isystem$(NXDK_DIR)/lib \
                -isystem$(NXDK_DIR)/lib/xboxrt/libc_extensions \
-               -isystem$(NXDK_DIR)/lib/hal \
                -isystem$(NXDK_DIR)/lib/pdclib/include \
                -isystem$(NXDK_DIR)/lib/pdclib/platform/xbox/include \
                -isystem$(NXDK_DIR)/lib/winapi \

--- a/lib/net/nforceif/include/arch/cc.h
+++ b/lib/net/nforceif/include/arch/cc.h
@@ -36,7 +36,7 @@
 
 /* Include some files for defining library routines */
 #include <string.h>
-#include <debug.h>
+#include <hal/debug.h>
 #include <windows.h>
 
 #define printf debugPrint

--- a/lib/xboxrt/c_runtime/check_stack.c
+++ b/lib/xboxrt/c_runtime/check_stack.c
@@ -1,5 +1,5 @@
 #include <debug.h>
-#include "xboxkrnl/xboxkrnl.h"
+#include <xboxkrnl/xboxkrnl.h>
 
 #ifdef DEBUG_CONSOLE
     #define _print DbgPrint

--- a/lib/xboxrt/c_runtime/check_stack.c
+++ b/lib/xboxrt/c_runtime/check_stack.c
@@ -1,4 +1,4 @@
-#include <debug.h>
+#include <hal/debug.h>
 #include <xboxkrnl/xboxkrnl.h>
 
 #ifdef DEBUG_CONSOLE


### PR DESCRIPTION
Removes lib/hal from includes to prevent implicit includes in the future (should probably move to separate PR).

The motivation is to fix an issue in Neverball. Neverball has a file called `share/video.h` which is included by just using `#include "video.h"`; nxdk master will find `hal/video.h` first instead, which leads to undeclared functions, which then breaks behaviour at runtime.
~While the issue was already mitigated by using `-isystem` in upstream PR 258~ (update: 258 did not land), it is still bad to have such generic include names in the root of an include-path.

FIXME:
- Update submodules:
    ```
    $ grep -R \<debug\.h\> | grep incl
    sdl/SDL2/src/video/xbox/SDL_xbframebuffer.c:#include <debug.h>
    pdclib/platform/xbox/functions/assert/assert.c:#include <debug.h>
    ```