### PR TITLE
 Add nxdk specific wrapper for CMake

### DIFF
--- a/usr/bin/nxdk-cmake
+++ b/usr/bin/nxdk-cmake
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+CMAKE="cmake"
+
+${CMAKE} \
+  -DCMAKE_TOOLCHAIN_FILE=${NXDK_DIR}/usr/share/nxdk/toolchain-nxdk.cmake \
+  "$@"

--- a/usr/bin/nxdk-pkg-config
+++ b/usr/bin/nxdk-pkg-config
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+export PKG_CONFIG_LIBDIR=""
+export PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR}:${NXDK_DIR}/usr/lib/pkgconfig"
+export PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR}:${NXDK_DIR}/usr/local/lib/pkgconfig"
+
+PKG_CONFIG="pkg-config"
+
+${PKG_CONFIG} \
+  --define-variable=NXDK_DIR=${NXDK_DIR} \
+  "$@"

--- a/usr/lib/pkgconfig/sdl2.pc
+++ b/usr/lib/pkgconfig/sdl2.pc
@@ -1,0 +1,9 @@
+# sdl pkg-config source file
+
+Name: sdl2
+Description: Simple DirectMedia Layer is a cross-platform multimedia library designed to provide low level access to audio, keyboard, mouse, joystick, 3D hardware via OpenGL, and 2D video framebuffer.
+Version: 2.0.9
+Requires:
+Conflicts:
+Libs: ${NXDK_DIR}/lib/libSDL2.lib
+Cflags: -I${NXDK_DIR}/lib/sdl/SDL2/include

--- a/usr/share/cmake/Modules/FindSDL2.cmake
+++ b/usr/share/cmake/Modules/FindSDL2.cmake
@@ -1,0 +1,43 @@
+# Create imported target SDL2::SDL2
+
+set(SDL_DIR "${NXDK_DIR}/lib/sdl/SDL2")
+file(GLOB SDL_SRCS
+
+  # Based on Makefile.minimal (some backends adapted for Xbox
+  ${SDL_DIR}/src/*.c
+  ${SDL_DIR}/src/audio/*.c
+  ${SDL_DIR}/src/audio/xbox/*.c
+  ${SDL_DIR}/src/cpuinfo/*.c
+  ${SDL_DIR}/src/events/*.c
+  ${SDL_DIR}/src/file/*.c
+  ${SDL_DIR}/src/haptic/*.c
+  ${SDL_DIR}/src/haptic/dummy/*.c
+  ${SDL_DIR}/src/joystick/*.c
+  ${SDL_DIR}/src/joystick/xbox/*.c
+  ${SDL_DIR}/src/loadso/dummy/*.c
+  ${SDL_DIR}/src/power/*.c
+  ${SDL_DIR}/src/filesystem/dummy/*.c
+  ${SDL_DIR}/src/render/*.c
+  ${SDL_DIR}/src/render/software/*.c
+  ${SDL_DIR}/src/sensor/*.c
+  ${SDL_DIR}/src/sensor/dummy/*.c
+  ${SDL_DIR}/src/stdlib/*.c
+  ${SDL_DIR}/src/thread/*.c
+  ${SDL_DIR}/src/thread/windows/*.c
+  ${SDL_DIR}/src/timer/*.c
+  ${SDL_DIR}/src/timer/windows/*.c
+  ${SDL_DIR}/src/video/*.c
+  ${SDL_DIR}/src/video/xbox/*.c
+  ${SDL_DIR}/src/video/yuv2rgb/*.c
+
+  # Additions for Xbox
+  ${SDL_DIR}/src/libm/*.c
+  ${SDL_DIR}/src/atomic/*.c
+)
+
+add_library(SDL2 STATIC ${SDL_SRCS})
+target_compile_definitions(SDL2 PUBLIC -DXBOX=1)
+target_include_directories(SDL2 SYSTEM PUBLIC "${SDL_DIR}/include")
+
+add_library(SDL2::SDL2 INTERFACE IMPORTED)
+target_link_libraries(SDL2::SDL2 INTERFACE SDL2)

--- a/usr/share/cmake/Modules/FindThreads.cmake
+++ b/usr/share/cmake/Modules/FindThreads.cmake
@@ -1,0 +1,4 @@
+# xboxkrnl and pdclib have C11 thread support out of the box
+set(CMAKE_HAVE_THREADS_LIBRARY 1)
+set(Threads_FOUND TRUE)
+add_library(Threads::Threads INTERFACE IMPORTED)

--- a/usr/share/nxdk/toolchain-nxdk.cmake
+++ b/usr/share/nxdk/toolchain-nxdk.cmake
@@ -16,7 +16,8 @@ endif()
 #FIXME: Include stuff for MinGW / Windows-GNU / Windows-Clang?
 #FIXME: How to set the ABI?
 
-set(NXDK_LINK_XBE "${NXDK_DIR}/usr/bin/${TOOLCHAIN_PREFIX}-exe2xbe -OUT:<TARGET>.xbe <TARGET>.exe")
+#set(NXDK_LINK_XBE "${NXDK_DIR}/usr/bin/${TOOLCHAIN_PREFIX}-exe2xbe -OUT:<TARGET>.xbe <TARGET>.exe")
+set(NXDK_LINK_XBE "")
 
 # cross compiler to use for C
 set(CMAKE_C_COMPILER "${NXDK_DIR}/usr/bin/${TOOLCHAIN_PREFIX}-cc")

--- a/usr/share/nxdk/toolchain-nxdk.cmake
+++ b/usr/share/nxdk/toolchain-nxdk.cmake
@@ -1,0 +1,46 @@
+set(NXDK_DIR $ENV{NXDK_DIR})
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR Generic) #FIXME: Pentium 3
+set(TOOLCHAIN_PREFIX nxdk)
+
+set(WIN32 1)
+
+set(NXDK 1)
+
+# Keep depfiles to track header changes
+if(NOT "${lang}" STREQUAL "ASM")
+  set(CMAKE_DEPFILE_FLAGS_${lang} "-MD -MT <OBJECT> -MF <DEPFILE>")
+endif()
+
+#FIXME: Include stuff for MinGW / Windows-GNU / Windows-Clang?
+#FIXME: How to set the ABI?
+
+set(NXDK_LINK_XBE "${NXDK_DIR}/usr/bin/${TOOLCHAIN_PREFIX}-exe2xbe -OUT:<TARGET>.xbe <TARGET>.exe")
+
+# cross compiler to use for C
+set(CMAKE_C_COMPILER "${NXDK_DIR}/usr/bin/${TOOLCHAIN_PREFIX}-cc")
+set(CMAKE_C_STANDARD_LIBRARIES "${NXDK_DIR}/lib/libwinapi.lib ${NXDK_DIR}/lib/xboxkrnl/libxboxkrnl.lib ${NXDK_DIR}/lib/libxboxrt.lib  ${NXDK_DIR}/lib/libpdclib.lib ${NXDK_DIR}/lib/libnxdk_hal.lib ${NXDK_DIR}/lib/libnxdk.lib ${NXDK_DIR}/lib/libnxdk_usb.lib") #"${CMAKE_CXX_STANDARD_LIBRARIES_INIT}"
+set(CMAKE_C_LINK_EXECUTABLE "${NXDK_DIR}/usr/bin/${TOOLCHAIN_PREFIX}-link <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -out:<TARGET>.exe <LINK_LIBRARIES>; ${NXDK_LINK_XBE}")
+
+# cross compiler to use for C++
+set(CMAKE_CXX_COMPILER "${NXDK_DIR}/usr/bin/${TOOLCHAIN_PREFIX}-c++")
+set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} ${NXDK_DIR}/lib/libc++.lib")
+set(CMAKE_CXX_LINK_EXECUTABLE "${NXDK_DIR}/usr/bin/${TOOLCHAIN_PREFIX}-link <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -out:<TARGET>.exe <LINK_LIBRARIES>; ${NXDK_LINK_XBE}")
+
+
+function(create_xiso output_file input_folder)
+    add_custom_target(xiso ALL
+        COMMAND "${NXDK_DIR}/usr/bin/${TOOLCHAIN_PREFIX}-xiso" "-c" "${input_folder}" "${output_file}"
+        COMMENT "Creating XISO"
+    )
+endfunction()
+
+
+set(CMAKE_SYSROOT "${NXDK_DIR}")
+set(CMAKE_MODULE_PATH "${NXDK_DIR}/usr/share/cmake/Modules/")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/usr/share/nxdk/toolchain-nxdk.cmake
+++ b/usr/share/nxdk/toolchain-nxdk.cmake
@@ -39,7 +39,8 @@ endfunction()
 
 
 set(CMAKE_SYSROOT "${NXDK_DIR}")
-set(CMAKE_MODULE_PATH "${NXDK_DIR}/usr/share/cmake/Modules/")
+#message("TOOLCHAIN ${CMAKE_MODULE_PATH}")
+#set(CMAKE_MODULE_PATH "${NXDK_DIR}/usr/share/cmake/Modules/")
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
Based on #82

This is a prototype for CMake support.

Based on xboxrt and winapi being libs (upstream PR 325).

Includes many tests, although I intend to split most of them into a separate branch for unit testing.
There's probably no need to include these ports in nxdk.