### PR TITLE
Add nxdk specific wrappers to expose a common toolchain interface

### DIFF
--- a/.ci_build_samples.sh
+++ b/.ci_build_samples.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+export NXDK_DIR=`pwd`
+export PATH="${PATH}:${NXDK_DIR}/usr/bin:${NXDK_DIR}/usr/local/bin"
+
 if [ $(uname) = 'Darwin' ]; then
     NUMCORES=$(sysctl -n hw.logicalcpu)
 else

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ endif
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
+LD           = nxdk-link
+LIB          = nxdk-lib
+AS           = nxdk-as
+CC           = nxdk-cc
+CXX          = nxdk-c++
 ifeq ($(UNAME_S),Linux)
-LD           = lld -flavor link
-LIB          = llvm-lib
-AS           = clang
-CC           = clang
-CXX          = clang++
 ifneq ($(UNAME_M),x86_64)
 CGC          = $(NXDK_DIR)/tools/cg/linux/cgc.i386
 else
@@ -26,22 +26,12 @@ CGC          = $(NXDK_DIR)/tools/cg/linux/cgc
 endif #UNAME_M != x86_64
 endif
 ifeq ($(UNAME_S),Darwin)
-LD           = /usr/local/opt/llvm/bin/lld -flavor link
-LIB          = /usr/local/opt/llvm/bin/llvm-lib
-AS           = /usr/local/opt/llvm/bin/clang
-CC           = /usr/local/opt/llvm/bin/clang
-CXX          = /usr/local/opt/llvm/bin/clang++
 CGC          = $(NXDK_DIR)/tools/cg/mac/cgc
 endif
 ifneq (,$(findstring MSYS_NT,$(UNAME_S)))
 $(error Please use a MinGW64 shell)
 endif
 ifneq (,$(findstring MINGW,$(UNAME_S)))
-LD           = lld-link
-LIB          = llvm-lib
-AS           = clang
-CC           = clang
-CXX          = clang++
 CGC          = $(NXDK_DIR)/tools/cg/win/cgc
 endif
 
@@ -51,20 +41,6 @@ VP20COMPILER = $(NXDK_DIR)/tools/vp20compiler/vp20compiler
 FP20COMPILER = $(NXDK_DIR)/tools/fp20compiler/fp20compiler
 EXTRACT_XISO = $(NXDK_DIR)/tools/extract-xiso/build/extract-xiso
 TOOLS        = cxbe vp20compiler fp20compiler extract-xiso
-NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
-               -ffreestanding -nostdlib -fno-builtin \
-               -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt/libc_extensions \
-               -I$(NXDK_DIR)/lib/hal \
-               -isystem $(NXDK_DIR)/lib/pdclib/include \
-               -I$(NXDK_DIR)/lib/pdclib/platform/xbox/include \
-               -I$(NXDK_DIR)/lib/winapi \
-               -I$(NXDK_DIR)/lib/xboxrt/vcruntime \
-               -DNXDK -D__STDC__=1
-NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
-               -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
-NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-exceptions
-NXDK_LDFLAGS = -subsystem:windows -fixed -base:0x00010000 \
-               -stack:65536 -safeseh:no -merge:.edata=.edataxb
 
 ifeq ($(DEBUG),y)
 NXDK_ASFLAGS += -g -gdwarf-4

--- a/Makefile
+++ b/Makefile
@@ -18,22 +18,7 @@ LIB          = nxdk-lib
 AS           = nxdk-as
 CC           = nxdk-cc
 CXX          = nxdk-c++
-ifeq ($(UNAME_S),Linux)
-ifneq ($(UNAME_M),x86_64)
-CGC          = $(NXDK_DIR)/tools/cg/linux/cgc.i386
-else
-CGC          = $(NXDK_DIR)/tools/cg/linux/cgc
-endif #UNAME_M != x86_64
-endif
-ifeq ($(UNAME_S),Darwin)
-CGC          = $(NXDK_DIR)/tools/cg/mac/cgc
-endif
-ifneq (,$(findstring MSYS_NT,$(UNAME_S)))
-$(error Please use a MinGW64 shell)
-endif
-ifneq (,$(findstring MINGW,$(UNAME_S)))
-CGC          = $(NXDK_DIR)/tools/cg/win/cgc
-endif
+CGC          = nxdk-cgc
 
 TARGET       = $(OUTPUT_DIR)/default.xbe
 CXBE         = $(NXDK_DIR)/tools/cxbe/cxbe

--- a/usr/bin/nxdk-ar
+++ b/usr/bin/nxdk-ar
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+LLVM_AR=llvm-ar
+
+${LLVM_AR} \
+  "$@"

--- a/usr/bin/nxdk-as
+++ b/usr/bin/nxdk-as
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+if [ "$OS" = "macos" ]; then
+  CLANG="/usr/local/opt/llvm/bin/clang"
+else
+  CLANG="clang"
+fi
+
+${CLANG} \
+  ${NXDK_CFLAGS} \
+  -fuse-ld=nxdk-link \
+  "$@"

--- a/usr/bin/nxdk-c++
+++ b/usr/bin/nxdk-c++
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+if [ "$OS" = "macos" ]; then
+  CLANG="/usr/local/opt/llvm/bin/clang"
+else
+  CLANG="clang"
+fi
+
+${CLANG} \
+  ${NXDK_CXXFLAGS} \
+  -fuse-ld=nxdk-link \
+  "$@"

--- a/usr/bin/nxdk-cc
+++ b/usr/bin/nxdk-cc
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+if [ "$OS" = "macos" ]; then
+  CLANG="/usr/local/opt/llvm/bin/clang"
+else
+  CLANG="clang"
+fi
+
+${CLANG} \
+  ${NXDK_CFLAGS} \
+  -fuse-ld=nxdk-link \
+  "$@"

--- a/usr/bin/nxdk-cgc
+++ b/usr/bin/nxdk-cgc
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+if [ "$OS" = "macos" ]; then
+  CGC="${NXDK_DIR}/tools/cg/mac/cgc"
+elif [ "$OS" = "linux" ]; then
+  if [ "$UNAME_M" = "x86_64" ]; then
+    CGC="${NXDK_DIR}/tools/cg/linux/cgc"
+  elif [ "$UNAME_M" = "i686" ]; then
+    CGC="${NXDK_DIR}/tools/cg/linux/cgc.i386"
+  else
+    error "unsupported CPU architecture (${UNAME_M})"
+    exit 1
+  fi
+elif [ "$OS" = "mingw" ]; then
+  CGC="${NXDK_DIR}/tools/cg/win/cgc"
+else
+  error "unsupported operating system (${OS})"
+  exit 1
+fi
+
+${CGC} \
+  "$@"

--- a/usr/bin/nxdk-fp20compiler
+++ b/usr/bin/nxdk-fp20compiler
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+FP20COMPILER=${NXDK_DIR}/tools/fp20compiler/fp20compiler
+
+${FP20COMPILER} \
+  "$@"

--- a/usr/bin/nxdk-lib
+++ b/usr/bin/nxdk-lib
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+if [ "$OS" = "macos" ]; then
+  LLVM_LIB="/usr/local/opt/llvm/bin/llvm-lib"
+else
+  LLVM_LIB="llvm-lib"
+fi
+
+# Workaround for LLVM 6 on Ubuntu, where they didn't symlink llvm-lib:
+# See https://github.com/XboxDev/nxdk/issues/196
+if [ ! "$(command -v ${LLVM_LIB})" ]; then
+  warning "Unable to find llvm-lib, using workaround"
+  LLVM_LIB="/usr/lib/llvm-6.0/bin/llvm-lib"
+  if [ ! "$(command -v ${LLVM_LIB})" ]; then
+    error "Workaround did not work; llvm-lib not found"
+    exit 1
+  fi
+fi
+
+${LLVM_LIB} \
+  "$@"

--- a/usr/bin/nxdk-link
+++ b/usr/bin/nxdk-link
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+if [ "$OS" = "macos" ]; then
+  LLD_LINK="/usr/local/opt/llvm/bin/lld -flavor link"
+elif [ "$OS" = "linux" ]; then
+  LLD_LINK="lld -flavor link"
+else
+  LLD_LINK="lld-link"
+fi
+
+${LLD_LINK} ${NXDK_LDFLAGS} \
+  ${NXDK_DIR}/lib/libwinapi.lib \
+  ${NXDK_DIR}/lib/xboxkrnl/libxboxkrnl.lib \
+  ${NXDK_DIR}/lib/libxboxrt.lib \
+  ${NXDK_DIR}/lib/libpdclib.lib \
+  ${NXDK_DIR}/lib/libnxdk_hal.lib \
+  ${NXDK_DIR}/lib/libnxdk.lib \
+  ${NXDK_DIR}/lib/libnxdk_usb.lib \
+  -LIBPATH:${NXDK_DIR}/lib \
+  -LIBPATH:${NXDK_DIR}/usr/lib \
+  -LIBPATH:${NXDK_DIR}/usr/local/lib \
+  "$@"

--- a/usr/bin/nxdk-ranlib
+++ b/usr/bin/nxdk-ranlib
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+LLVM_LIB=llvm-lib
+LLVM_RANLIB=llvm-ranlib
+
+aPath=$(dirname $1)
+aFilename=$(basename $1)
+
+${LLVM_RANLIB} \
+  $aPath/$aFilename
+
+# Remove "lib" prefix and replace extension .a by .lib
+libPath=$aPath
+libFilename=$aFilename
+libFilename=${libFilename#lib}
+libFilename=${libFilename%.a}.lib
+
+# Create a .lib version of the .a file
+${LLVM_LIB} \
+  -out:$libPath/$libFilename \
+  $aPath/$aFilename

--- a/usr/bin/nxdk-vp20compiler
+++ b/usr/bin/nxdk-vp20compiler
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+VP20COMPILER=${NXDK_DIR}/tools/vp20compiler/vp20compiler
+
+${VP20COMPILER} \
+  "$@"

--- a/usr/share/nxdk/flags.inl
+++ b/usr/share/nxdk/flags.inl
@@ -1,0 +1,16 @@
+NXDK_CFLAGS="-target i386-pc-win32 -march=pentium3 \
+             -ffreestanding -nostdlib -fno-builtin \
+             -I${NXDK_DIR}/lib -I${NXDK_DIR}/lib/xboxrt/libc_extensions \
+             -I${NXDK_DIR}/lib/hal \
+             -isystem ${NXDK_DIR}/lib/pdclib/include \
+             -I${NXDK_DIR}/lib/pdclib/platform/xbox/include \
+             -I${NXDK_DIR}/lib/winapi \
+             -I${NXDK_DIR}/lib/xboxrt/vcruntime \
+             -I${NXDK_DIR}/usr/include \
+             -I${NXDK_DIR}/usr/local/include \
+             -DNXDK -D__XBOX__=1 -D__STDC__=1"
+NXDK_ASFLAGS="-target i386-pc-win32 -march=pentium3 \
+              -nostdlib -I${NXDK_DIR}/lib -I${NXDK_DIR}/lib/xboxrt"
+NXDK_CXXFLAGS="-I${NXDK_DIR}/lib/libcxx/include ${NXDK_CFLAGS} -fno-exceptions"
+NXDK_LDFLAGS="-subsystem:windows -fixed -base:0x00010000 \
+              -stack:65536 -safeseh:no -merge:.edata=.edataxb"

--- a/usr/share/nxdk/prelude.inl
+++ b/usr/share/nxdk/prelude.inl
@@ -1,0 +1,38 @@
+set -u
+set -e
+
+# Add nxdk tools to path
+PATH="${PATH}:${NXDK_DIR}/usr/bin:${NXDK_DIR}/usr/local/bin"
+
+# Find platform information
+UNAME_S=$(uname -s)
+UNAME_M=$(uname -m)
+
+# Find a more useful OS name
+case "$UNAME_S" in
+  Linux*)     OS=linux;;
+  Darwin*)    OS=macos;;
+  CYGWIN*)    OS=cygwin;;
+  MINGW*)     OS=mingw;;
+  *)          OS="unknown:${UNAME_S}"
+esac
+
+# Expose compiler flags
+. ${NXDK_DIR}/usr/share/nxdk/flags.inl
+
+# Color codes
+COLOR_YELLOW='\033[1;33m'
+COLOR_RED='\033[0;31m'
+COLOR_NONE='\033[0m'
+
+# Helper to print a warning message
+warning()
+{
+  echo -e "$(basename $0): ${COLOR_YELLOW}warning:${COLOR_NONE} $@"
+}
+
+# Helper to print an error message
+error()
+{
+  echo -e "$(basename $0): ${COLOR_RED}error:${COLOR_NONE} $@\n"
+}


### PR DESCRIPTION
- **Note**: This does not touch how nxdk itself is build. It's also fully backwards compatible with existing projects.

    Future changes to the nxdk buildsystem are planned though. The plan is to eventually decouple application building from nxdk initialization / installation / bootstrapping.

---

This is something that should have happend a long time ago.
A redesign of the nxdk build-system, so that applications that don't want to use the nxdk Makefile can be created much more easily.

### How to use this

Configure `NXDK_DIR` in your shell, then add the nxdk binaries to the path.

Assuming you are currently in the nxdk-dir, just run these:
```bash
export NXDK_DIR=`pwd`
export PATH="${PATH}:${NXDK_DIR}/usr/bin:${NXDK_DIR}/usr/local/bin"
```

*(Personally, I just have a variant of this in my `~/.bash_profile`. Because all binaries are nxdk prefixed, it's easy to use them with tab-completion)*

Once you have configured your `NXDK_DIR`, you must do a one-time initialization for your nxdk installation using; these steps must be done only once after cloning or updating nxdk:

```bash
make -C ${NXDK_DIR}/samples/sdl
make -C ${NXDK_DIR}/samples/httpd
```
*(Specifically, these commands will build samples which also force compilation of optional libraries, such as SDL2 and networking)*

After this one-time initalization you can just use nxdk like this:

```bash
echo -e '#include <hal/debug.h>\nint main() { debugPrint("Hello world"); while(1); }' > xboxapp.c
nxdk-cc xboxapp.c -o default.exe
${NXDK_DIR}/tools/cxbe default.exe -OUT:default.xbe
file default.xbe
```

The most complicated step in this is probably cxbe, which can be improved in the future (see below for more information).

These scripts will also help with abstraction of the implementation.
We can implement backwards compatibility in these scripts, add platform specific workarounds, etc.

### The Future

This is the starting point for nxdk support in a variety of build-systems:

- https://github.com/JayFoxRox/nxdk/pull/85: pkg-config
- https://github.com/JayFoxRox/nxdk/pull/83: autoconf
- https://github.com/JayFoxRox/nxdk/pull/74: CMake

With these additional tools it will be trivial to compile many libraries.
You will be able to `make install`; future projects that you are building with nxdk will automatically find those installed libraries.

I have successfully compiled and installed the following libs without any changes, just by following steps from their README (or common sense:

- FIXME: autoconf samples
- https://github.com/JayFoxRox/nxdk/pull/84: CMake samples

Instead of mirroring build-systems, we can just have minimalistic scripts to trigger compilation with the projects appropriate build-system.
This will also be very suitable for integration with package-managers in the future.

There are also plans to redesign XISO and XBE creation.
For development this means that we can replace underlying tools (such as extract-xiso and cxbe) without breakage:

- https://github.com/JayFoxRox/nxdk/pull/86: XISO and XBE creation abstraction and CLI redesign

This will be useful for people who use Makefiles directly or have custom build-systems.
It will be even easier to compile nxdk apps from the command line.

---

## TODO

I did not try running any of the resulting EXE/XBEs