### PR TITLE
Add nxdk specific wrapper for autoconf

### DIFF
--- a/usr/bin/nxdk-configure
+++ b/usr/bin/nxdk-configure
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+#FIXME: add explicit support for SDL / SDL2?
+#       https://wiki.libsdl.org/FAQLinux#how_do_i_add_sdl_to_my_project
+
+# Wrapper around autoconf ./configure scripts
+./configure \
+  CC=nxdk-cc \
+  CXX=nxdk-c++ \
+  AR=nxdk-ar \
+  RANLIB=nxdk-ranlib \
+  PKG_CONFIG=nxdk-pkg-config \
+  --host=i686-windows --prefix=${NXDK_DIR}/usr/local "$@"

--- a/usr/bin/nxdk-pkg-config
+++ b/usr/bin/nxdk-pkg-config
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+export PKG_CONFIG_LIBDIR=""
+export PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR}:${NXDK_DIR}/usr/lib/pkgconfig"
+export PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR}:${NXDK_DIR}/usr/local/lib/pkgconfig"
+
+PKG_CONFIG="pkg-config"
+
+${PKG_CONFIG} \
+  --define-variable=NXDK_DIR=${NXDK_DIR} \
+  "$@"

--- a/usr/lib/pkgconfig/sdl2.pc
+++ b/usr/lib/pkgconfig/sdl2.pc
@@ -1,0 +1,9 @@
+# sdl pkg-config source file
+
+Name: sdl2
+Description: Simple DirectMedia Layer is a cross-platform multimedia library designed to provide low level access to audio, keyboard, mouse, joystick, 3D hardware via OpenGL, and 2D video framebuffer.
+Version: 2.0.9
+Requires:
+Conflicts:
+Libs: ${NXDK_DIR}/lib/libSDL2.lib
+Cflags: -I${NXDK_DIR}/lib/sdl/SDL2/include


### PR DESCRIPTION
Based on #82 

Might try to use other host tools or files, because autoconf is a bit of a trainwreck. Use with caution.

Another approach to this would be to have `nxdk-autoconf` (the tool which generates the `./configure` script file) which could add a custom `config.sub` entry (which contains all supported systems) to add an nxdk platform.

Fun find along those lines: https://github.com/autotools-mirror/autoconf/blame/b3eb40f9c9919e5c40762cab1196715bd8796af1/build-aux/config.sub#L1262-L1265

---


Tested with:

- https://github.com/Teufelchen1/libSDL_gfx/pull/1 for building and installing the lib
    ```
    nxdk-configure
    make
    make install
    ```
- https://github.com/XboxDev/nxdk-sdl/pull/39 to support https://github.com/Teufelchen1/libSDL_gfx/pull/2  for building the test application
    ```
    nxdk-configure
    make
    ```
- Also builds freetype and SDL2_ttf out of the box, using `autoconf` (= installs pkg-config files so it can be found and used by other projects)

I did not try running any of the resulting EXE/XBEs