### PR TITLE
Add nxdk specific wrapper for XBE & XISO creation

### DIFF
--- a/usr/bin/nxdk-exe2xbe
+++ b/usr/bin/nxdk-exe2xbe
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+CXBE=${NXDK_DIR}/tools/cxbe/cxbe
+
+${CXBE} \
+  "$@" > /dev/null

--- a/usr/bin/nxdk-xiso
+++ b/usr/bin/nxdk-xiso
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+. ${NXDK_DIR}/usr/share/nxdk/prelude.inl
+
+EXTRACT_XISO=${NXDK_DIR}/tools/extract-xiso/build/extract-xiso
+
+${EXTRACT_XISO} \
+  "$@"


### PR DESCRIPTION
Once these `nxdk-` wrappers land, it might be hard to introduce breaking changes.

So this was split from the rest of the bin wrappers because I didn't want to add too many new interfaces.
Specifically, I was concerned with bikeshedding over interface design.